### PR TITLE
Add AngularTutor starter solution and setup instructions

### DIFF
--- a/AngularTutor/AngularTutor.sln
+++ b/AngularTutor/AngularTutor.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AngularTutor", "AngularTutor\AngularTutor.csproj", "{6F5B70CC-3E0A-4F6F-A84E-7A13F7883F9E}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{6F5B70CC-3E0A-4F6F-A84E-7A13F7883F9E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{6F5B70CC-3E0A-4F6F-A84E-7A13F7883F9E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{6F5B70CC-3E0A-4F6F-A84E-7A13F7883F9E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{6F5B70CC-3E0A-4F6F-A84E-7A13F7883F9E}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+GlobalSection(ExtensibilityGlobals) = postSolution
+SolutionGuid = {F1F57C38-94E4-4143-B4C6-54110E6B6C75}
+EndGlobalSection
+EndGlobal

--- a/AngularTutor/AngularTutor/AngularTutor.csproj
+++ b/AngularTutor/AngularTutor/AngularTutor.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>AngularTutor</RootNamespace>
+    <AssemblyName>AngularTutor</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/AngularTutor/AngularTutor/Controllers/StatusController.cs
+++ b/AngularTutor/AngularTutor/Controllers/StatusController.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace AngularTutor.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class StatusController : ControllerBase
+{
+    [HttpGet]
+    public IActionResult Get()
+    {
+        return Ok(new
+        {
+            service = "AngularTutor API",
+            status = "online",
+            timestamp = DateTime.UtcNow,
+        });
+    }
+}

--- a/AngularTutor/AngularTutor/Program.cs
+++ b/AngularTutor/AngularTutor/Program.cs
@@ -1,0 +1,33 @@
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "AngularTutor API",
+        Version = "v1",
+        Description = "Starter API for Angular + ASP.NET Core tutorial",
+    });
+});
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/AngularTutor/AngularTutor/appsettings.json
+++ b/AngularTutor/AngularTutor/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "SqlServer": "Server=localhost;Database=AngularTutor;Trusted_Connection=True;TrustServerCertificate=True;"
+  }
+}

--- a/AngularTutor/instructions.md
+++ b/AngularTutor/instructions.md
@@ -1,0 +1,80 @@
+# AngularTutor bootstrap instructions
+
+This repository contains a starter Visual Studio 2022 solution (`AngularTutor.sln`) with an ASP.NET Core Web API project intended to back an Angular front end.
+Use this guide to finish setting up the stack and create a working site that combines Angular, C# .NET Core, and SQL Server.
+
+## Prerequisites
+- Visual Studio 2022 with **ASP.NET and web development** workload installed.
+- SQL Server (Express or Developer) reachable from your development machine.
+- Node.js 18+ and the Angular CLI (`npm install -g @angular/cli`) for building the client.
+
+## Solution layout
+```
+AngularTutor.sln
+└─ AngularTutor\              # ASP.NET Core Web API
+   ├─ AngularTutor.csproj
+   ├─ Program.cs
+   ├─ Controllers\StatusController.cs
+   └─ appsettings.json        # contains a starter SQL Server connection string
+```
+
+### How to open in VS 2022
+1. Open `AngularTutor.sln` in Visual Studio 2022.
+2. Restore NuGet packages if prompted.
+3. Set **AngularTutor** as the startup project.
+4. Press **F5** to launch the API with Swagger UI (available in Development environment).
+
+## Building the API
+1. Right-click the **AngularTutor** project → **Manage NuGet Packages** → install:
+   - `Microsoft.EntityFrameworkCore.SqlServer`
+   - `Microsoft.EntityFrameworkCore.Tools`
+   - `Swashbuckle.AspNetCore` (already referenced in `Program.cs` for Swagger)
+2. Update `appsettings.json` with your SQL Server connection string under `ConnectionStrings:SqlServer`.
+3. Add your data models and `DbContext`, e.g. `Data/ApplicationDbContext.cs` with `DbSet<T>` properties.
+4. Register the context in `Program.cs`:
+   ```csharp
+   builder.Services.AddDbContext<ApplicationDbContext>(options =>
+       options.UseSqlServer(builder.Configuration.GetConnectionString("SqlServer")));
+   ```
+5. Create a RESTful controller per resource (e.g. `Controllers/CoursesController.cs`) using `[ApiController]`, `GET/POST/PUT/DELETE` actions, and `IActionResult` return types.
+6. Use Entity Framework Core migrations to create/update the database:
+   - **Package Manager Console**: `Add-Migration InitialCreate` then `Update-Database`.
+   - Or **dotnet CLI**: `dotnet ef migrations add InitialCreate` then `dotnet ef database update`.
+
+## Building the Angular client
+1. From the repository root, scaffold an Angular app (outside the API project folder):
+   ```bash
+   ng new angular-tutor-client --routing --style=scss
+   cd angular-tutor-client
+   ng serve -o
+   ```
+2. Create Angular services that consume the API via `HttpClient` (e.g. `status.service.ts`, `courses.service.ts`). Point the base URL to your API host/port.
+3. Build pages/components that match your API resources. Use Angular routing to organize feature modules.
+4. For a unified developer experience, configure an Angular proxy (`proxy.conf.json`) to forward `/api` calls to `https://localhost:5001` and run `ng serve --proxy-config proxy.conf.json`.
+
+## Connecting Angular and ASP.NET Core
+- Enable CORS in `Program.cs` so the Angular dev server can call the API:
+  ```csharp
+  var allowedOrigins = "AngularDev";
+  builder.Services.AddCors(options =>
+      options.AddPolicy(allowedOrigins, policy =>
+          policy.WithOrigins("https://localhost:4200")
+                .AllowAnyHeader()
+                .AllowAnyMethod()));
+
+  app.UseCors(allowedOrigins);
+  ```
+- Expose well-documented RESTful endpoints and verify them via Swagger before wiring up Angular.
+- If you prefer a single deployable artifact, you can host the Angular build output in `wwwroot` by adding `builder.Services.AddSpaStaticFiles` and copying `dist/` assets into the API project during publish.
+
+## Database considerations
+- Use code-first migrations for schema evolution; keep migrations checked into source control.
+- Seed reference data in a hosted service or migration to keep environments consistent.
+- For local development, use SQL Server Express LocalDB or a containerized SQL Server instance.
+
+## Quality and testing
+- Write integration tests against in-memory test servers using `WebApplicationFactory` to validate REST endpoints.
+- Add Angular unit tests (`ng test`) and end-to-end tests (`ng e2e`) as you build features.
+- Use Swagger/OpenAPI for contract verification between the Angular client and ASP.NET Core API.
+
+With these steps, you can grow the starter API into a full Angular + ASP.NET Core + SQL Server application while staying productive in Visual Studio 2022.


### PR DESCRIPTION
## Summary
- add AngularTutor solution scaffolded for VS 2022 with ASP.NET Core Web API starter project
- include configuration, Swagger-ready Program.cs, and a sample status endpoint for REST verification
- document Angular, .NET Core, and SQL Server setup steps in instructions.md

## Testing
- Not run (dotnet CLI unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931007a3580832da895574f957f508e)