### PR TITLE
Phase 5: implement ASP-to-Angular migration pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ src/
 ├── Phase2-CoreLanguage/   # [IMPLEMENTED] Language feature conversion (CodeGeneration, Converters)
 ├── Phase3-FormsUI/        # [IMPLEMENTED] WinForms conversion (Layout, FormParsing)
 ├── Phase4-DataAccess/     # [IMPLEMENTED] Database migration (ADO, SQL, EF)
-├── Phase5-ASPtoAngular/   # [STUBBED] Web stack migration (Parser, Backend, Frontend)
+├── Phase5-ASPtoAngular/   # [IMPLEMENTED] ASP/VBScript parsing, analysis, .NET 8 API + standalone Angular 17+ generation, DB (see README.md)
 ├── Phase6-Advanced/       # [STUBBED] COM, Late Binding, Optimize
 ├── Phase7-Optimization/   # [STUBBED] Code Cleanup, Refactoring
 └── Phase8-Tooling/        # [STUBBED] CLI, IDE integration
@@ -94,7 +94,10 @@ All core phases have been structurally implemented.
 - **Phase 2**: Core converters (Variable, ControlFlow) and Generator are implemented.
 - **Phase 3**: LayoutConverter implements `.frm` parsing and WinForms Designer generation.
 - **Phase 4**: Basic ADO and Schema generators stubbed/implemented.
-- **Phase 5-8**: Stubs created for all core components.
+- **Phase 5**: Real ASP/VBScript parser, analysis passes, .NET 8 Web API backend generation,
+  standalone Angular 17+ frontend generation with an anti-pattern checker, and DB generation
+  (delegates to Phase 4). Wired end-to-end via `AspProjectConverter` / CLI `convert-asp-project`.
+- **Phase 6-8**: Stubs created for all core components.
 
 ### Build Configuration
 

--- a/docs/Phase5-ASPtoAngular-TODO.md
+++ b/docs/Phase5-ASPtoAngular-TODO.md
@@ -51,8 +51,29 @@ It currently contains PowerShell, Blazor, and Razor Pages artifacts that sketch 
 
 ## Remaining follow-up
 
-1. Build the actual ASP analysis and conversion pipeline.
-2. Decide whether the target output is Angular, Blazor, Razor Pages, or a split architecture.
-3. Replace placeholder navigation and viewer templates with generated artifacts driven by real schema and page metadata.
-4. Add executable conversion tests with sample classic ASP inputs and expected outputs.
-5. Bring naming, packaging, and project integration up to production quality.
+1. ~~Build the actual ASP analysis and conversion pipeline.~~ Done - see below.
+2. ~~Decide whether the target output is Angular, Blazor, Razor Pages, or a split architecture.~~
+   Decided: Angular. The `RazorPages/` prototype above is unaffected/unchanged; it just isn't
+   the direction taken.
+3. Replace placeholder navigation and viewer templates with generated artifacts driven by real
+   schema and page metadata. (Applies to the `RazorPages/` prototype specifically; the Angular
+   pipeline below generates its own templates from real page metadata.)
+4. ~~Add executable conversion tests with sample classic ASP inputs and expected outputs.~~ Done
+   for the Angular pipeline - see `tests/BLML.Tests/Phase5AspToAngularTests.cs`.
+5. Bring naming, packaging, and project integration up to production quality. (Still applies to
+   `RazorPages/`; not attempted here.)
+
+## Angular pipeline added
+
+A real ASP-to-Angular conversion pipeline now exists under `src/Phase5-ASPtoAngular/` alongside
+(not replacing) the `RazorPages/` prototype: `AspParser/` (classic ASP/VBScript lexer and
+parser), `Analysis/` (business-logic classification, session tracking, ADO call analysis, page
+flow), `Backend/` (.NET 8 Web API generation), `Frontend/` (standalone Angular 17+ generation
+with `AngularAntiPatternChecker`), and `Database/` (delegates to Phase 4's EF Core/schema
+generators). `AspProjectConverter` runs the whole thing end-to-end, exposed via the CLI as
+`convert-asp-project`. See `src/Phase5-ASPtoAngular/README.md`'s "Platform decision" section for
+the full breakdown, and `tests/BLML.Tests/Phase5AspToAngularTests.cs` for coverage of every
+piece plus an end-to-end test.
+
+Follow-up items 3 and 5 above still apply to the `RazorPages/` prototype specifically, which was
+out of scope for this pass.

--- a/src/BLML.Transpiler.csproj
+++ b/src/BLML.Transpiler.csproj
@@ -18,7 +18,6 @@
     <Compile Remove="Phase3-FormsUI\FormParsing\vb6formparser.cs" />
     <Compile Remove="Phase3-FormsUI\FormParsing\vb6binary.cs" />
     <Compile Remove="Phase4-DataAccess\**\*.cs" />
-    <Compile Remove="Phase5-ASPtoAngular\**\*.cs" />
     <Compile Remove="Phase6-Advanced\**\*.cs" />
     <Compile Remove="Phase7-Optimization\**\*.cs" />
     <Compile Remove="Phase8-Tooling\**\*.cs" />
@@ -37,24 +36,6 @@
     <Compile Include="Phase7-Optimization\CodeCleanup\DeadCodeRemover.cs" />
     <Compile Include="Phase7-Optimization\Documentation\XmlDocGenerator.cs" />
     <Compile Include="Phase7-Optimization\Refactoring\LinqOptimizer.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Analysis\DatabaseCallAnalyzer.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Analysis\PageFlowAnalyzer.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Analysis\SessionVariableTracker.cs" />
-    <Compile Include="Phase5-ASPtoAngular\AspParser\AspLexer.cs" />
-    <Compile Include="Phase5-ASPtoAngular\AspParser\AspParser.cs" />
-    <Compile Include="Phase5-ASPtoAngular\AspParser\VBScriptParser.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Backend\ApiGenerator\ControllerGenerator.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Backend\ApiGenerator\DtoGenerator.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Backend\ApiGenerator\ServiceGenerator.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Backend\Infrastructure\AuthConverter.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Backend\Infrastructure\MiddlewareGenerator.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Database\EFCoreGenerator.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Database\MigrationScripts.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Database\RepositoryGenerator.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Frontend\ComponentGenerator.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Frontend\FormConverter.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Frontend\RoutingGenerator.cs" />
-    <Compile Include="Phase5-ASPtoAngular\Frontend\TemplateConverter.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Phase5-ASPtoAngular/Analysis/BusinessLogicExtractor.cs
+++ b/src/Phase5-ASPtoAngular/Analysis/BusinessLogicExtractor.cs
@@ -1,0 +1,203 @@
+using BLML.Phase1Foundation.AST;
+using BLML.Phase5ASPtoAngular.AspParser;
+
+namespace BLML.Phase5ASPtoAngular.Analysis
+{
+    public enum StatementKind
+    {
+        /// <summary>Literal HTML or an output expression - belongs in the Angular template.</summary>
+        Presentation,
+        /// <summary>Database/session/control-flow work - belongs in the generated API service.</summary>
+        BusinessLogic,
+        /// <summary>Neither clearly - left in place for a human to sort out.</summary>
+        Ambiguous
+    }
+
+    public class ClassifiedStatement
+    {
+        public StatementNode Statement { get; set; } = null!;
+        public StatementKind Kind { get; set; }
+        public string Reason { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Classic ASP pages routinely interleave data access, session/auth checks, and
+    /// HTML rendering in one file with no separation of concerns. This walks a parsed
+    /// page's statement tree and tags each statement as presentation (HTML/output -
+    /// becomes the Angular template) or business logic (ADO/session/auth work -
+    /// becomes API service code), so the backend/frontend generators know which is
+    /// which without re-deriving it themselves.
+    ///
+    /// This is a heuristic, not a proof: an assignment is judged business logic only
+    /// when its right-hand side mentions a known data-access/session identifier
+    /// (Server.CreateObject, an ADODB.* ProgID, Session/Application/Request access,
+    /// or a variable already tagged business logic earlier in the same page/sub -
+    /// i.e. classification propagates along simple def-use chains). Anything it can't
+    /// confidently place either way is marked Ambiguous rather than guessed at.
+    /// </summary>
+    public class BusinessLogicExtractor
+    {
+        private static readonly string[] DataAccessMarkers =
+        {
+            "adodb", "createobject", "connection", "recordset", "command",
+            "execute", "moveNext".ToLowerInvariant(), "fields", "commandtext"
+        };
+
+        private static readonly string[] SessionAuthMarkers =
+        {
+            "session", "application", "request", "response.redirect", "server.mappath"
+        };
+
+        public List<ClassifiedStatement> Classify(IEnumerable<StatementNode> statements)
+        {
+            var results = new List<ClassifiedStatement>();
+            var businessLogicVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            Walk(statements, results, businessLogicVariables);
+            return results;
+        }
+
+        private void Walk(IEnumerable<StatementNode> statements, List<ClassifiedStatement> results, HashSet<string> businessLogicVariables)
+        {
+            foreach (var stmt in statements)
+            {
+                switch (stmt)
+                {
+                    case HtmlOutputStatementNode:
+                    case AspOutputExpressionStatementNode:
+                        results.Add(new ClassifiedStatement { Statement = stmt, Kind = StatementKind.Presentation, Reason = "Literal HTML or inline output expression." });
+                        break;
+
+                    case AssignmentNode assign:
+                        results.Add(ClassifyAssignment(assign, businessLogicVariables));
+                        break;
+
+                    case CallStatementNode call:
+                        results.Add(ClassifyExpression(call, call.Invocation, "Statement-level call"));
+                        break;
+
+                    case VariableDeclarationGroupNode:
+                        results.Add(new ClassifiedStatement { Statement = stmt, Kind = StatementKind.Ambiguous, Reason = "Declaration only; classification follows from later assignment." });
+                        break;
+
+                    case IfStatementNode ifStmt:
+                        results.Add(new ClassifiedStatement { Statement = ifStmt, Kind = ContainsAnyMarker(ExpressionToSearchText(ifStmt.Condition), SessionAuthMarkers) ? StatementKind.BusinessLogic : StatementKind.Ambiguous, Reason = "If condition; see nested statements for the branches." });
+                        Walk(ifStmt.TrueBlock.Statements, results, businessLogicVariables);
+                        if (ifStmt.ElseBlock != null) Walk(ifStmt.ElseBlock.Statements, results, businessLogicVariables);
+                        break;
+
+                    case SingleLineIfStatementNode single:
+                        Walk(new[] { single.ThenStatement }, results, businessLogicVariables);
+                        if (single.ElseStatement != null) Walk(new[] { single.ElseStatement }, results, businessLogicVariables);
+                        break;
+
+                    case WhileStatementNode whileStmt:
+                        results.Add(new ClassifiedStatement { Statement = whileStmt, Kind = ContainsAnyMarker(ExpressionToSearchText(whileStmt.Condition), DataAccessMarkers) ? StatementKind.BusinessLogic : StatementKind.Ambiguous, Reason = "Loop condition; see nested statements for the body." });
+                        Walk(whileStmt.Body.Statements, results, businessLogicVariables);
+                        break;
+
+                    case DoLoopStatementNode doLoop:
+                        Walk(doLoop.Body.Statements, results, businessLogicVariables);
+                        break;
+
+                    case ForStatementNode forStmt:
+                        Walk(forStmt.Body.Statements, results, businessLogicVariables);
+                        break;
+
+                    case ForEachStatementNode forEach:
+                        Walk(forEach.Body.Statements, results, businessLogicVariables);
+                        break;
+
+                    case SelectCaseStatementNode select:
+                        foreach (var c in select.Cases) Walk(c.Body.Statements, results, businessLogicVariables);
+                        if (select.CaseElseBlock != null) Walk(select.CaseElseBlock.Statements, results, businessLogicVariables);
+                        break;
+
+                    default:
+                        results.Add(new ClassifiedStatement { Statement = stmt, Kind = StatementKind.Ambiguous, Reason = "No classification rule for this statement type." });
+                        break;
+                }
+            }
+        }
+
+        private ClassifiedStatement ClassifyAssignment(AssignmentNode assign, HashSet<string> businessLogicVariables)
+        {
+            var rhsText = ExpressionToSearchText(assign.Value);
+            var targetName = (assign.Target as IdentifierExpressionNode)?.Name;
+
+            bool isBusinessLogic = ContainsAnyMarker(rhsText, DataAccessMarkers)
+                || ContainsAnyMarker(rhsText, SessionAuthMarkers)
+                || ReferencesAny(assign.Value, businessLogicVariables);
+
+            if (isBusinessLogic && targetName != null) businessLogicVariables.Add(targetName);
+
+            return new ClassifiedStatement
+            {
+                Statement = assign,
+                Kind = isBusinessLogic ? StatementKind.BusinessLogic : StatementKind.Ambiguous,
+                Reason = isBusinessLogic
+                    ? "Right-hand side references data access/session state."
+                    : "No known data-access/session marker found; defaulting to ambiguous rather than presentation."
+            };
+        }
+
+        private ClassifiedStatement ClassifyExpression(StatementNode stmt, ExpressionNode expr, string label)
+        {
+            var text = ExpressionToSearchText(expr);
+            bool isDataAccess = ContainsAnyMarker(text, DataAccessMarkers);
+            bool isSessionAuth = ContainsAnyMarker(text, SessionAuthMarkers);
+            bool isPresentation = text.Contains("response.write", StringComparison.OrdinalIgnoreCase);
+
+            if (isDataAccess || isSessionAuth)
+            {
+                return new ClassifiedStatement { Statement = stmt, Kind = StatementKind.BusinessLogic, Reason = $"{label} touches data access or session/auth state." };
+            }
+            if (isPresentation)
+            {
+                return new ClassifiedStatement { Statement = stmt, Kind = StatementKind.Presentation, Reason = $"{label} writes directly to the response." };
+            }
+            return new ClassifiedStatement { Statement = stmt, Kind = StatementKind.Ambiguous, Reason = $"{label} did not match a known classification rule." };
+        }
+
+        private static bool ReferencesAny(ExpressionNode expr, HashSet<string> names)
+        {
+            if (names.Count == 0) return false;
+            return CollectIdentifiers(expr).Any(names.Contains);
+        }
+
+        private static IEnumerable<string> CollectIdentifiers(ExpressionNode expr)
+        {
+            switch (expr)
+            {
+                case IdentifierExpressionNode id:
+                    yield return id.Name;
+                    break;
+                case BinaryExpressionNode bin:
+                    if (bin.Left != null) foreach (var n in CollectIdentifiers(bin.Left)) yield return n;
+                    if (bin.Right != null) foreach (var n in CollectIdentifiers(bin.Right)) yield return n;
+                    break;
+                case InvocationExpressionNode inv:
+                    foreach (var n in CollectIdentifiers(inv.Target)) yield return n;
+                    foreach (var arg in inv.Arguments)
+                        foreach (var n in CollectIdentifiers(arg)) yield return n;
+                    break;
+            }
+        }
+
+        /// <summary>Flattens an expression tree to lowercase text for simple substring marker matching.</summary>
+        private static string ExpressionToSearchText(ExpressionNode? expr)
+        {
+            if (expr is null) return string.Empty;
+            return expr switch
+            {
+                IdentifierExpressionNode id => id.Name,
+                LiteralExpressionNode lit => lit.Value?.ToString() ?? string.Empty,
+                BinaryExpressionNode bin => $"{ExpressionToSearchText(bin.Left)} {bin.Operator} {ExpressionToSearchText(bin.Right)}",
+                InvocationExpressionNode inv => $"{ExpressionToSearchText(inv.Target)}({string.Join(",", inv.Arguments.Select(ExpressionToSearchText))})",
+                _ => string.Empty
+            };
+        }
+
+        private static bool ContainsAnyMarker(string text, string[] markers) =>
+            markers.Any(m => text.Contains(m, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/Phase5-ASPtoAngular/Analysis/DatabaseCallAnalyzer.cs
+++ b/src/Phase5-ASPtoAngular/Analysis/DatabaseCallAnalyzer.cs
@@ -8,10 +8,12 @@ namespace BLML.Phase5ASPtoAngular.Analysis
 
     public class DatabaseCallSite
     {
-        /// <summary>Reconstructed SQL text: literal fragments verbatim, non-literal operands rendered as `?`.</summary>
+        /// <summary>Reconstructed SQL text: literal fragments verbatim, non-literal operands rendered as `?` in order.</summary>
         public string SqlText { get; set; } = string.Empty;
         /// <summary>True when the SQL was assembled by string concatenation with a non-literal operand - a SQL-injection risk unless parameterized.</summary>
         public bool BuiltByUnsafeConcatenation { get; set; }
+        /// <summary>Best-effort source text of each `?` placeholder in <see cref="SqlText"/>, in order - what ServiceGenerator binds as SqlParameters.</summary>
+        public List<string> ConcatenatedParameterExpressions { get; } = new();
         public List<string> TablesReferenced { get; } = new();
         public StatementNode Statement { get; set; } = null!;
     }
@@ -43,6 +45,82 @@ namespace BLML.Phase5ASPtoAngular.Analysis
             var objects = new Dictionary<string, AdoObjectInfo>(StringComparer.OrdinalIgnoreCase);
             Walk(statements, objects);
             return objects.Values.ToList();
+        }
+
+        /// <summary>
+        /// Finds every `rsVar("FieldName")` read for the given recordset variable, in
+        /// source order with duplicates removed - this is what drives DtoGenerator's
+        /// best-effort field list, since classic ASP has no schema to read the shape
+        /// from directly.
+        /// </summary>
+        public List<string> FindFieldReferences(IEnumerable<StatementNode> statements, string recordsetVariable)
+        {
+            var fields = new List<string>();
+            foreach (var expr in EnumerateExpressions(statements))
+            {
+                if (expr is InvocationExpressionNode inv
+                    && inv.Target is IdentifierExpressionNode id
+                    && string.Equals(id.Name, recordsetVariable, StringComparison.OrdinalIgnoreCase)
+                    && inv.Arguments.Count == 1
+                    && inv.Arguments[0] is LiteralExpressionNode { Value: string field }
+                    && !fields.Contains(field, StringComparer.OrdinalIgnoreCase))
+                {
+                    fields.Add(field);
+                }
+            }
+            return fields;
+        }
+
+        private static IEnumerable<ExpressionNode> EnumerateExpressions(IEnumerable<StatementNode> statements)
+        {
+            foreach (var stmt in statements)
+            {
+                IEnumerable<ExpressionNode> here = stmt switch
+                {
+                    AssignmentNode a => new[] { a.Target, a.Value },
+                    CallStatementNode c => new[] { c.Invocation },
+                    AspOutputExpressionStatementNode o => new[] { o.Expression },
+                    IfStatementNode i => new[] { i.Condition },
+                    SingleLineIfStatementNode s => new[] { s.Condition },
+                    WhileStatementNode w => new[] { w.Condition },
+                    _ => Enumerable.Empty<ExpressionNode>()
+                };
+                foreach (var e in here)
+                    foreach (var sub in EnumerateSubExpressions(e))
+                        yield return sub;
+
+                IEnumerable<StatementNode>? nested = stmt switch
+                {
+                    IfStatementNode i => i.ElseBlock is null ? i.TrueBlock.Statements : i.TrueBlock.Statements.Concat(i.ElseBlock.Statements),
+                    SingleLineIfStatementNode s => s.ElseStatement is null ? new[] { s.ThenStatement } : new[] { s.ThenStatement, s.ElseStatement },
+                    WhileStatementNode w => w.Body.Statements,
+                    DoLoopStatementNode d => d.Body.Statements,
+                    ForStatementNode f => f.Body.Statements,
+                    ForEachStatementNode fe => fe.Body.Statements,
+                    SelectCaseStatementNode sc => sc.Cases.SelectMany(c => c.Body.Statements).Concat(sc.CaseElseBlock?.Statements ?? Enumerable.Empty<StatementNode>()),
+                    _ => null
+                };
+                if (nested != null)
+                    foreach (var e in EnumerateExpressions(nested))
+                        yield return e;
+            }
+        }
+
+        private static IEnumerable<ExpressionNode> EnumerateSubExpressions(ExpressionNode expr)
+        {
+            yield return expr;
+            switch (expr)
+            {
+                case BinaryExpressionNode bin:
+                    if (bin.Left != null) foreach (var e in EnumerateSubExpressions(bin.Left)) yield return e;
+                    if (bin.Right != null) foreach (var e in EnumerateSubExpressions(bin.Right)) yield return e;
+                    break;
+                case InvocationExpressionNode inv:
+                    foreach (var e in EnumerateSubExpressions(inv.Target)) yield return e;
+                    foreach (var arg in inv.Arguments)
+                        foreach (var e in EnumerateSubExpressions(arg)) yield return e;
+                    break;
+            }
         }
 
         private void Walk(IEnumerable<StatementNode> statements, Dictionary<string, AdoObjectInfo> objects)
@@ -118,8 +196,10 @@ namespace BLML.Phase5ASPtoAngular.Analysis
 
         private static DatabaseCallSite BuildCallSite(ExpressionNode sqlExpr, StatementNode statement)
         {
-            var (text, unsafeConcat) = ReconstructSql(sqlExpr);
-            var site = new DatabaseCallSite { SqlText = text, BuiltByUnsafeConcatenation = unsafeConcat, Statement = statement };
+            var site = new DatabaseCallSite { Statement = statement };
+            var (text, unsafeConcat) = ReconstructSql(sqlExpr, site.ConcatenatedParameterExpressions);
+            site.SqlText = text;
+            site.BuiltByUnsafeConcatenation = unsafeConcat;
             foreach (Match m in TableRegex.Matches(text))
             {
                 var table = m.Groups[1].Value;
@@ -134,20 +214,30 @@ namespace BLML.Phase5ASPtoAngular.Analysis
         /// etc.) and reporting whether such a substitution was needed at all - that's
         /// the "was this built unsafely" signal.
         /// </summary>
-        private static (string text, bool unsafeConcat) ReconstructSql(ExpressionNode expr)
+        private static (string text, bool unsafeConcat) ReconstructSql(ExpressionNode expr, List<string> parameterExpressions)
         {
             switch (expr)
             {
                 case LiteralExpressionNode { Value: string s }:
                     return (s, false);
                 case BinaryExpressionNode { Operator: "&" } bin:
-                    var (leftText, leftUnsafe) = ReconstructSql(bin.Left);
-                    var (rightText, rightUnsafe) = ReconstructSql(bin.Right);
+                    var (leftText, leftUnsafe) = ReconstructSql(bin.Left, parameterExpressions);
+                    var (rightText, rightUnsafe) = ReconstructSql(bin.Right, parameterExpressions);
                     return (leftText + rightText, leftUnsafe || rightUnsafe);
                 default:
+                    parameterExpressions.Add(DescribeExpression(expr));
                     return ("?", true);
             }
         }
+
+        private static string DescribeExpression(ExpressionNode expr) => expr switch
+        {
+            IdentifierExpressionNode id => id.Name,
+            LiteralExpressionNode lit => lit.Value?.ToString() ?? "",
+            BinaryExpressionNode { Operator: "." } member => $"{DescribeExpression(member.Left)}.{DescribeExpression(member.Right)}",
+            InvocationExpressionNode inv => $"{DescribeExpression(inv.Target)}({string.Join(",", inv.Arguments.Select(DescribeExpression))})",
+            _ => "expr"
+        };
 
         private static bool TryGetCreateObjectProgId(ExpressionNode expr, out string? progId)
         {

--- a/src/Phase5-ASPtoAngular/Analysis/DatabaseCallAnalyzer.cs
+++ b/src/Phase5-ASPtoAngular/Analysis/DatabaseCallAnalyzer.cs
@@ -1,10 +1,172 @@
+using System.Text.RegularExpressions;
+using BLML.Phase1Foundation.AST;
+using BLML.Phase5ASPtoAngular.AspParser;
+
 namespace BLML.Phase5ASPtoAngular.Analysis
 {
+    public enum AdoObjectKind { Connection, Recordset, Command, Unknown }
+
+    public class DatabaseCallSite
+    {
+        /// <summary>Reconstructed SQL text: literal fragments verbatim, non-literal operands rendered as `?`.</summary>
+        public string SqlText { get; set; } = string.Empty;
+        /// <summary>True when the SQL was assembled by string concatenation with a non-literal operand - a SQL-injection risk unless parameterized.</summary>
+        public bool BuiltByUnsafeConcatenation { get; set; }
+        public List<string> TablesReferenced { get; } = new();
+        public StatementNode Statement { get; set; } = null!;
+    }
+
+    public class AdoObjectInfo
+    {
+        public string VariableName { get; set; } = string.Empty;
+        public AdoObjectKind Kind { get; set; }
+        public List<DatabaseCallSite> CallSites { get; } = new();
+    }
+
+    /// <summary>
+    /// Finds ADO usage in a parsed page: `Server.CreateObject("ADODB.*")` object
+    /// creation, `.Open`/`.Execute`/`.CommandText =` call sites, and reconstructs the
+    /// SQL each site runs well enough to (a) name the tables involved and (b) flag the
+    /// single most common classic-ASP data-access anti-pattern: building a SQL string
+    /// by concatenating raw user input instead of using parameters. That flag is the
+    /// signal ServiceGenerator uses to always emit parameterized commands regardless
+    /// of what the original code did.
+    /// </summary>
     public class DatabaseCallAnalyzer
     {
-        public void FindSqlCalls(string content)
+        private static readonly Regex TableRegex = new(
+            @"\b(?:FROM|INTO|UPDATE|JOIN)\s+\[?([A-Za-z_][A-Za-z0-9_]*)\]?",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public List<AdoObjectInfo> Analyze(IEnumerable<StatementNode> statements)
         {
-            // Find SQL strings and ADO calls
+            var objects = new Dictionary<string, AdoObjectInfo>(StringComparer.OrdinalIgnoreCase);
+            Walk(statements, objects);
+            return objects.Values.ToList();
         }
+
+        private void Walk(IEnumerable<StatementNode> statements, Dictionary<string, AdoObjectInfo> objects)
+        {
+            foreach (var stmt in statements)
+            {
+                switch (stmt)
+                {
+                    case AssignmentNode assign:
+                        HandleAssignment(assign, objects);
+                        break;
+                    case CallStatementNode call:
+                        HandleCall(call.Invocation, call, objects);
+                        break;
+                    case IfStatementNode ifStmt:
+                        Walk(ifStmt.TrueBlock.Statements, objects);
+                        if (ifStmt.ElseBlock != null) Walk(ifStmt.ElseBlock.Statements, objects);
+                        break;
+                    case SingleLineIfStatementNode single:
+                        Walk(new[] { single.ThenStatement }, objects);
+                        if (single.ElseStatement != null) Walk(new[] { single.ElseStatement }, objects);
+                        break;
+                    case WhileStatementNode whileStmt: Walk(whileStmt.Body.Statements, objects); break;
+                    case DoLoopStatementNode doLoop: Walk(doLoop.Body.Statements, objects); break;
+                    case ForStatementNode forStmt: Walk(forStmt.Body.Statements, objects); break;
+                    case ForEachStatementNode forEach: Walk(forEach.Body.Statements, objects); break;
+                    case SelectCaseStatementNode select:
+                        foreach (var c in select.Cases) Walk(c.Body.Statements, objects);
+                        if (select.CaseElseBlock != null) Walk(select.CaseElseBlock.Statements, objects);
+                        break;
+                }
+            }
+        }
+
+        private void HandleAssignment(AssignmentNode assign, Dictionary<string, AdoObjectInfo> objects)
+        {
+            var targetName = (assign.Target as IdentifierExpressionNode)?.Name;
+
+            if (targetName != null && TryGetCreateObjectProgId(assign.Value, out var progId))
+            {
+                objects[targetName] = new AdoObjectInfo { VariableName = targetName, Kind = ClassifyProgId(progId!) };
+                return;
+            }
+
+            // rs.CommandText = "SELECT ..." / cmd.CommandText = "..."
+            if (assign.Target is BinaryExpressionNode { Operator: "." } member
+                && member.Left is IdentifierExpressionNode ownerId
+                && member.Right is IdentifierExpressionNode prop
+                && string.Equals(prop.Name, "CommandText", StringComparison.OrdinalIgnoreCase)
+                && objects.TryGetValue(ownerId.Name, out var owner))
+            {
+                owner.CallSites.Add(BuildCallSite(assign.Value, assign));
+            }
+        }
+
+        private void HandleCall(ExpressionNode invocationExpr, StatementNode statement, Dictionary<string, AdoObjectInfo> objects)
+        {
+            if (invocationExpr is not InvocationExpressionNode inv) return;
+            if (inv.Target is not BinaryExpressionNode { Operator: "." } member) return;
+            if (member.Left is not IdentifierExpressionNode ownerId) return;
+            if (member.Right is not IdentifierExpressionNode method) return;
+            if (!objects.TryGetValue(ownerId.Name, out var owner)) return;
+
+            if (string.Equals(method.Name, "Open", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(method.Name, "Execute", StringComparison.OrdinalIgnoreCase))
+            {
+                if (inv.Arguments.Count > 0)
+                {
+                    owner.CallSites.Add(BuildCallSite(inv.Arguments[0], statement));
+                }
+            }
+        }
+
+        private static DatabaseCallSite BuildCallSite(ExpressionNode sqlExpr, StatementNode statement)
+        {
+            var (text, unsafeConcat) = ReconstructSql(sqlExpr);
+            var site = new DatabaseCallSite { SqlText = text, BuiltByUnsafeConcatenation = unsafeConcat, Statement = statement };
+            foreach (Match m in TableRegex.Matches(text))
+            {
+                var table = m.Groups[1].Value;
+                if (!site.TablesReferenced.Contains(table, StringComparer.OrdinalIgnoreCase)) site.TablesReferenced.Add(table);
+            }
+            return site;
+        }
+
+        /// <summary>
+        /// Rebuilds a best-effort SQL string from a `&amp;`-concatenation expression tree,
+        /// substituting `?` for any non-literal operand (a variable, a function call,
+        /// etc.) and reporting whether such a substitution was needed at all - that's
+        /// the "was this built unsafely" signal.
+        /// </summary>
+        private static (string text, bool unsafeConcat) ReconstructSql(ExpressionNode expr)
+        {
+            switch (expr)
+            {
+                case LiteralExpressionNode { Value: string s }:
+                    return (s, false);
+                case BinaryExpressionNode { Operator: "&" } bin:
+                    var (leftText, leftUnsafe) = ReconstructSql(bin.Left);
+                    var (rightText, rightUnsafe) = ReconstructSql(bin.Right);
+                    return (leftText + rightText, leftUnsafe || rightUnsafe);
+                default:
+                    return ("?", true);
+            }
+        }
+
+        private static bool TryGetCreateObjectProgId(ExpressionNode expr, out string? progId)
+        {
+            progId = null;
+            if (expr is not InvocationExpressionNode inv) return false;
+            if (inv.Target is not BinaryExpressionNode { Operator: "." } member) return false;
+            if (member.Left is not IdentifierExpressionNode server || !string.Equals(server.Name, "Server", StringComparison.OrdinalIgnoreCase)) return false;
+            if (member.Right is not IdentifierExpressionNode method || !string.Equals(method.Name, "CreateObject", StringComparison.OrdinalIgnoreCase)) return false;
+            if (inv.Arguments.Count != 1 || inv.Arguments[0] is not LiteralExpressionNode { Value: string s }) return false;
+            progId = s;
+            return true;
+        }
+
+        private static AdoObjectKind ClassifyProgId(string progId) => progId.ToLowerInvariant() switch
+        {
+            "adodb.connection" => AdoObjectKind.Connection,
+            "adodb.recordset" => AdoObjectKind.Recordset,
+            "adodb.command" => AdoObjectKind.Command,
+            _ => AdoObjectKind.Unknown
+        };
     }
 }

--- a/src/Phase5-ASPtoAngular/Analysis/PageFlowAnalyzer.cs
+++ b/src/Phase5-ASPtoAngular/Analysis/PageFlowAnalyzer.cs
@@ -1,10 +1,146 @@
+using System.Text.RegularExpressions;
+using BLML.Phase1Foundation.AST;
+using BLML.Phase5ASPtoAngular.AspParser;
+
 namespace BLML.Phase5ASPtoAngular.Analysis
 {
+    public enum PageFlowTrigger { Redirect, ServerTransfer, ServerExecute, FormSubmit, Link }
+
+    public class PageFlowEdge
+    {
+        public string FromPage { get; set; } = string.Empty;
+        public string ToPage { get; set; } = string.Empty;
+        public PageFlowTrigger Trigger { get; set; }
+        /// <summary>GET for a link/GET form, POST for a POST form; null for server-side redirects.</summary>
+        public string? HttpMethod { get; set; }
+    }
+
+    /// <summary>
+    /// Maps how a page reaches other pages: server-side navigation
+    /// (Response.Redirect/Server.Transfer/Server.Execute, found by walking the parsed
+    /// statement tree) plus client-side navigation baked into the emitted HTML
+    /// (`&lt;form action=...&gt;`, `&lt;a href=...&gt;`, matched with a regex over each
+    /// HtmlOutputStatementNode's raw text since that markup was never itself parsed as
+    /// VBScript). This becomes RoutingGenerator's page graph.
+    /// </summary>
     public class PageFlowAnalyzer
     {
-        public void AnalyzeFlow(string[] pages)
+        private static readonly Regex FormRegex = new(
+            "<form\\b[^>]*\\baction\\s*=\\s*[\"']([^\"']+)[\"'][^>]*>",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex FormMethodRegex = new(
+            "\\bmethod\\s*=\\s*[\"']([^\"']+)[\"']",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex LinkRegex = new(
+            "<a\\b[^>]*\\bhref\\s*=\\s*[\"']([^\"'#][^\"']*)[\"']",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public List<PageFlowEdge> Analyze(IEnumerable<StatementNode> statements, string currentPageName)
         {
-            // Analyze Response.Redirect and Server.Transfer
+            var edges = new List<PageFlowEdge>();
+            WalkStatements(statements, currentPageName, edges);
+            WalkHtml(statements, currentPageName, edges);
+            return edges;
+        }
+
+        private void WalkStatements(IEnumerable<StatementNode> statements, string page, List<PageFlowEdge> edges)
+        {
+            foreach (var stmt in statements)
+            {
+                switch (stmt)
+                {
+                    case CallStatementNode call:
+                        TryAddServerNavigation(call.Invocation, page, edges);
+                        break;
+                    case IfStatementNode ifStmt:
+                        WalkStatements(ifStmt.TrueBlock.Statements, page, edges);
+                        if (ifStmt.ElseBlock != null) WalkStatements(ifStmt.ElseBlock.Statements, page, edges);
+                        break;
+                    case SingleLineIfStatementNode single:
+                        WalkStatements(new[] { single.ThenStatement }, page, edges);
+                        if (single.ElseStatement != null) WalkStatements(new[] { single.ElseStatement }, page, edges);
+                        break;
+                    case WhileStatementNode whileStmt: WalkStatements(whileStmt.Body.Statements, page, edges); break;
+                    case DoLoopStatementNode doLoop: WalkStatements(doLoop.Body.Statements, page, edges); break;
+                    case ForStatementNode forStmt: WalkStatements(forStmt.Body.Statements, page, edges); break;
+                    case ForEachStatementNode forEach: WalkStatements(forEach.Body.Statements, page, edges); break;
+                    case SelectCaseStatementNode select:
+                        foreach (var c in select.Cases) WalkStatements(c.Body.Statements, page, edges);
+                        if (select.CaseElseBlock != null) WalkStatements(select.CaseElseBlock.Statements, page, edges);
+                        break;
+                }
+            }
+        }
+
+        private void TryAddServerNavigation(ExpressionNode invocationExpr, string page, List<PageFlowEdge> edges)
+        {
+            if (invocationExpr is not InvocationExpressionNode inv) return;
+            if (inv.Target is not BinaryExpressionNode { Operator: "." } member) return;
+            if (member.Left is not IdentifierExpressionNode owner) return;
+            if (member.Right is not IdentifierExpressionNode method) return;
+            if (inv.Arguments.Count == 0 || inv.Arguments[0] is not LiteralExpressionNode { Value: string target }) return;
+
+            PageFlowTrigger? trigger = (owner.Name.ToLowerInvariant(), method.Name.ToLowerInvariant()) switch
+            {
+                ("response", "redirect") => PageFlowTrigger.Redirect,
+                ("server", "transfer") => PageFlowTrigger.ServerTransfer,
+                ("server", "execute") => PageFlowTrigger.ServerExecute,
+                _ => null
+            };
+            if (trigger is null) return;
+
+            edges.Add(new PageFlowEdge { FromPage = page, ToPage = StripQueryString(target), Trigger = trigger.Value });
+        }
+
+        private void WalkHtml(IEnumerable<StatementNode> statements, string page, List<PageFlowEdge> edges)
+        {
+            foreach (var stmt in Flatten(statements))
+            {
+                if (stmt is not HtmlOutputStatementNode html) continue;
+
+                foreach (Match m in FormRegex.Matches(html.Html))
+                {
+                    var methodMatch = FormMethodRegex.Match(m.Value);
+                    var httpMethod = methodMatch.Success ? methodMatch.Groups[1].Value.ToUpperInvariant() : "GET";
+                    edges.Add(new PageFlowEdge { FromPage = page, ToPage = StripQueryString(m.Groups[1].Value), Trigger = PageFlowTrigger.FormSubmit, HttpMethod = httpMethod });
+                }
+
+                foreach (Match m in LinkRegex.Matches(html.Html))
+                {
+                    var href = m.Groups[1].Value;
+                    if (href.Contains("://") || href.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) continue;
+                    edges.Add(new PageFlowEdge { FromPage = page, ToPage = StripQueryString(href), Trigger = PageFlowTrigger.Link, HttpMethod = "GET" });
+                }
+            }
+        }
+
+        /// <summary>Depth-first flatten so html buried in If/While/etc. bodies is still scanned.</summary>
+        private static IEnumerable<StatementNode> Flatten(IEnumerable<StatementNode> statements)
+        {
+            foreach (var stmt in statements)
+            {
+                yield return stmt;
+                IEnumerable<StatementNode>? nested = stmt switch
+                {
+                    IfStatementNode i => i.ElseBlock is null ? i.TrueBlock.Statements : i.TrueBlock.Statements.Concat(i.ElseBlock.Statements),
+                    SingleLineIfStatementNode s => s.ElseStatement is null ? new[] { s.ThenStatement } : new[] { s.ThenStatement, s.ElseStatement },
+                    WhileStatementNode w => w.Body.Statements,
+                    DoLoopStatementNode d => d.Body.Statements,
+                    ForStatementNode f => f.Body.Statements,
+                    ForEachStatementNode fe => fe.Body.Statements,
+                    SelectCaseStatementNode sc => sc.Cases.SelectMany(c => c.Body.Statements).Concat(sc.CaseElseBlock?.Statements ?? Enumerable.Empty<StatementNode>()),
+                    _ => null
+                };
+                if (nested != null) foreach (var n in Flatten(nested)) yield return n;
+            }
+        }
+
+        private static string StripQueryString(string url)
+        {
+            var idx = url.IndexOf('?');
+            return idx >= 0 ? url[..idx] : url;
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/Analysis/SessionVariableTracker.cs
+++ b/src/Phase5-ASPtoAngular/Analysis/SessionVariableTracker.cs
@@ -1,10 +1,189 @@
+using BLML.Phase1Foundation.AST;
+using BLML.Phase5ASPtoAngular.AspParser;
+
 namespace BLML.Phase5ASPtoAngular.Analysis
 {
+    public enum SessionAccessMode { Read, Write }
+
+    /// <summary>
+    /// The three idioms real ASP code uses interchangeably (and inconsistently within
+    /// the same codebase) to ask "is this session variable unset" - genuinely
+    /// ambiguous in classic ASP because Session("x") on an unset key returns Empty,
+    /// which compares equal to both "" and vbNull-ish checks depending on how you ask.
+    /// Recording which idiom a site used lets AuthConverter normalize them all to one
+    /// C#/JWT-claim null check instead of guessing.
+    /// </summary>
+    public enum SessionNullCheckIdiom { EqualsEmptyString, IsEmptyCall, IsNothingComparison }
+
+    public class SessionAccessSite
+    {
+        public SessionAccessMode Mode { get; set; }
+        public StatementNode Statement { get; set; } = null!;
+    }
+
+    public class SessionVariableInfo
+    {
+        public string Name { get; set; } = string.Empty;
+        public List<SessionAccessSite> ReadSites { get; } = new();
+        public List<SessionAccessSite> WriteSites { get; } = new();
+        public List<SessionNullCheckIdiom> NullCheckIdiomsObserved { get; } = new();
+    }
+
+    /// <summary>
+    /// Catalogs every `Session("key")` read/write in a parsed page. Session state has
+    /// no direct equivalent in a stateless Web API, so this catalog is what
+    /// AuthConverter/MiddlewareGenerator use to decide, per key, whether it should
+    /// become a JWT claim (identity-ish keys like UserId/UserName/Role) or a
+    /// short-lived server-side cache entry (shopping-cart-ish keys).
+    /// </summary>
     public class SessionVariableTracker
     {
-        public void TrackSessionUsage(string content)
+        public Dictionary<string, SessionVariableInfo> Catalog(IEnumerable<StatementNode> statements)
         {
-            // Track Session("Key") usage
+            var result = new Dictionary<string, SessionVariableInfo>(StringComparer.OrdinalIgnoreCase);
+            Walk(statements, result);
+            return result;
+        }
+
+        private void Walk(IEnumerable<StatementNode> statements, Dictionary<string, SessionVariableInfo> catalog)
+        {
+            foreach (var stmt in statements)
+            {
+                switch (stmt)
+                {
+                    case AssignmentNode assign:
+                        if (TryGetSessionKey(assign.Target, out var writeKey))
+                        {
+                            RecordAccess(catalog, writeKey!, SessionAccessMode.Write, assign);
+                        }
+                        ScanExpressionForReads(assign.Value, assign, catalog);
+                        break;
+
+                    case CallStatementNode call:
+                        ScanExpressionForReads(call.Invocation, call, catalog);
+                        break;
+
+                    case AspOutputExpressionStatementNode output:
+                        ScanExpressionForReads(output.Expression, output, catalog);
+                        break;
+
+                    case IfStatementNode ifStmt:
+                        ScanExpressionForReads(ifStmt.Condition, ifStmt, catalog);
+                        DetectNullCheckInCondition(ifStmt.Condition, catalog);
+                        Walk(ifStmt.TrueBlock.Statements, catalog);
+                        if (ifStmt.ElseBlock != null) Walk(ifStmt.ElseBlock.Statements, catalog);
+                        break;
+
+                    case SingleLineIfStatementNode single:
+                        ScanExpressionForReads(single.Condition, single, catalog);
+                        DetectNullCheckInCondition(single.Condition, catalog);
+                        Walk(new[] { single.ThenStatement }, catalog);
+                        if (single.ElseStatement != null) Walk(new[] { single.ElseStatement }, catalog);
+                        break;
+
+                    case WhileStatementNode whileStmt:
+                        Walk(whileStmt.Body.Statements, catalog);
+                        break;
+                    case DoLoopStatementNode doLoop:
+                        Walk(doLoop.Body.Statements, catalog);
+                        break;
+                    case ForStatementNode forStmt:
+                        Walk(forStmt.Body.Statements, catalog);
+                        break;
+                    case ForEachStatementNode forEach:
+                        Walk(forEach.Body.Statements, catalog);
+                        break;
+                    case SelectCaseStatementNode select:
+                        foreach (var c in select.Cases) Walk(c.Body.Statements, catalog);
+                        if (select.CaseElseBlock != null) Walk(select.CaseElseBlock.Statements, catalog);
+                        break;
+                }
+            }
+        }
+
+        private void ScanExpressionForReads(ExpressionNode? expr, StatementNode owner, Dictionary<string, SessionVariableInfo> catalog)
+        {
+            if (expr is null) return;
+            if (TryGetSessionKey(expr, out var key))
+            {
+                RecordAccess(catalog, key!, SessionAccessMode.Read, owner);
+                return; // the Session(...) call itself is the leaf; don't also scan its literal argument
+            }
+            switch (expr)
+            {
+                case BinaryExpressionNode bin:
+                    ScanExpressionForReads(bin.Left, owner, catalog);
+                    ScanExpressionForReads(bin.Right, owner, catalog);
+                    break;
+                case InvocationExpressionNode inv:
+                    ScanExpressionForReads(inv.Target, owner, catalog);
+                    foreach (var arg in inv.Arguments) ScanExpressionForReads(arg, owner, catalog);
+                    break;
+            }
+        }
+
+        /// <summary>Matches `Session("key")` (an invocation of the identifier "Session" with one string-literal argument).</summary>
+        private static bool TryGetSessionKey(ExpressionNode expr, out string? key)
+        {
+            key = null;
+            if (expr is not InvocationExpressionNode inv) return false;
+            if (inv.Target is not IdentifierExpressionNode id || !string.Equals(id.Name, "Session", StringComparison.OrdinalIgnoreCase)) return false;
+            if (inv.Arguments.Count != 1 || inv.Arguments[0] is not LiteralExpressionNode lit) return false;
+            key = lit.Value?.ToString();
+            return key != null;
+        }
+
+        private static void RecordAccess(Dictionary<string, SessionVariableInfo> catalog, string name, SessionAccessMode mode, StatementNode statement)
+        {
+            if (!catalog.TryGetValue(name, out var info))
+            {
+                info = new SessionVariableInfo { Name = name };
+                catalog[name] = info;
+            }
+            var list = mode == SessionAccessMode.Read ? info.ReadSites : info.WriteSites;
+            list.Add(new SessionAccessSite { Mode = mode, Statement = statement });
+        }
+
+        private void DetectNullCheckInCondition(ExpressionNode condition, Dictionary<string, SessionVariableInfo> catalog)
+        {
+            // `If IsEmpty(Session("x")) Then` - IsEmpty(...) can be the *entire* condition,
+            // not just one side of a comparison, so this check has to run before (and
+            // independently of) the BinaryExpressionNode-only checks below.
+            if (condition is InvocationExpressionNode { Arguments.Count: 1 } isEmptyCall
+                && isEmptyCall.Target is IdentifierExpressionNode fn
+                && string.Equals(fn.Name, "IsEmpty", StringComparison.OrdinalIgnoreCase)
+                && TryGetSessionKey(isEmptyCall.Arguments[0], out var isEmptyKey))
+            {
+                NoteIdiom(catalog, isEmptyKey!, SessionNullCheckIdiom.IsEmptyCall);
+                return;
+            }
+
+            if (condition is not BinaryExpressionNode bin) return;
+
+            if (TryGetSessionKey(bin.Left, out var key1) || TryGetSessionKey(bin.Right, out key1))
+            {
+                var key = key1!;
+                bool comparesToEmptyString = string.Equals(bin.Operator, "=", StringComparison.Ordinal)
+                    && (IsEmptyStringLiteral(bin.Left) || IsEmptyStringLiteral(bin.Right));
+                bool comparesToNothing = string.Equals(bin.Operator, "Is", StringComparison.OrdinalIgnoreCase)
+                    && (IsNothingLiteral(bin.Left) || IsNothingLiteral(bin.Right));
+
+                if (comparesToEmptyString) NoteIdiom(catalog, key, SessionNullCheckIdiom.EqualsEmptyString);
+                else if (comparesToNothing) NoteIdiom(catalog, key, SessionNullCheckIdiom.IsNothingComparison);
+            }
+        }
+
+        private static bool IsEmptyStringLiteral(ExpressionNode expr) => expr is LiteralExpressionNode { Value: string s } && s.Length == 0;
+        private static bool IsNothingLiteral(ExpressionNode expr) => expr is LiteralExpressionNode { Value: null };
+
+        private static void NoteIdiom(Dictionary<string, SessionVariableInfo> catalog, string key, SessionNullCheckIdiom idiom)
+        {
+            if (!catalog.TryGetValue(key, out var info))
+            {
+                info = new SessionVariableInfo { Name = key };
+                catalog[key] = info;
+            }
+            if (!info.NullCheckIdiomsObserved.Contains(idiom)) info.NullCheckIdiomsObserved.Add(idiom);
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/AspParser/AspAstNodes.cs
+++ b/src/Phase5-ASPtoAngular/AspParser/AspAstNodes.cs
@@ -1,0 +1,87 @@
+using BLML.Phase1Foundation.AST;
+
+namespace BLML.Phase5ASPtoAngular.AspParser
+{
+    /// <summary>
+    /// A run of literal HTML/text output. In classic ASP, HTML sitting between
+    /// `%&gt;` and the next `&lt;%` is implicitly a Response.Write call, including when it sits
+    /// *inside* a VBScript block (e.g. `&lt;% If x Then %&gt;html&lt;% End If %&gt;`) - the html
+    /// belongs inside the If's body, not after it. AspParser slots these nodes into
+    /// whatever block body is currently open so that ambiguity resolves correctly.
+    /// </summary>
+    public class HtmlOutputStatementNode : StatementNode
+    {
+        public string Html { get; set; } = string.Empty;
+    }
+
+    /// <summary>An inline `&lt;%= expr %&gt;` output expression (shorthand for Response.Write(expr)).</summary>
+    public class AspOutputExpressionStatementNode : StatementNode
+    {
+        public ExpressionNode Expression { get; set; } = null!;
+        public string RawExpression { get; set; } = string.Empty;
+    }
+
+    /// <summary>A `Call` statement or bare invocation used as a statement (e.g. `rs.MoveNext`, `Response.Write x`).</summary>
+    public class CallStatementNode : StatementNode
+    {
+        public ExpressionNode Invocation { get; set; } = null!;
+    }
+
+    /// <summary>VBScript `Dim a, b(5), c` / `Const x = 1, y = 2` declares several names in one statement.</summary>
+    public class VariableDeclarationGroupNode : StatementNode
+    {
+        public List<VariableDeclarationNode> Declarations { get; } = new();
+    }
+
+    public class ForEachStatementNode : StatementNode
+    {
+        public string LoopVariable { get; set; } = string.Empty;
+        public ExpressionNode Collection { get; set; } = null!;
+        public BlockNode Body { get; set; } = new BlockNode();
+    }
+
+    public class SingleLineIfStatementNode : StatementNode
+    {
+        public ExpressionNode Condition { get; set; } = null!;
+        public StatementNode ThenStatement { get; set; } = null!;
+        public StatementNode? ElseStatement { get; set; }
+    }
+
+    /// <summary>
+    /// `&lt;%@ Language="VBScript" CodePage="65001" %&gt;` style page directive.
+    /// Must appear before any other output to be valid ASP, but real-world pages
+    /// are inconsistent about this - the parser records it wherever it's found.
+    /// </summary>
+    public class AspDirective
+    {
+        public Dictionary<string, string> Attributes { get; } = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>One `Session("x") = ...` or `... = Session("x")` reference site, with the ambiguous-null-check pattern (if any) noted.</summary>
+    public enum AspIntrinsicCollection
+    {
+        Session,
+        Application,
+        Request,
+        RequestForm,
+        RequestQueryString,
+        RequestCookies,
+        RequestServerVariables,
+        Response
+    }
+
+    /// <summary>
+    /// A parsed classic ASP page: directives + a flat statement stream where HTML,
+    /// `&lt;%= %&gt;` output, and VBScript control flow are interleaved in source order and
+    /// properly nested (If/For/etc. bodies contain the HTML that was physically
+    /// written inside them in the .asp file).
+    /// </summary>
+    public class AspPageNode
+    {
+        public string FilePath { get; set; } = string.Empty;
+        public List<AspDirective> Directives { get; } = new();
+        public List<StatementNode> Statements { get; } = new();
+        public List<string> ResolvedIncludePaths { get; } = new();
+        public List<string> ParseWarnings { get; } = new();
+    }
+}

--- a/src/Phase5-ASPtoAngular/AspParser/AspLexer.cs
+++ b/src/Phase5-ASPtoAngular/AspParser/AspLexer.cs
@@ -1,10 +1,204 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
 namespace BLML.Phase5ASPtoAngular.AspParser
 {
+    public enum AspRegionType
+    {
+        Html,
+        CodeBlock,
+        OutputExpression,
+        Directive,
+        ServerComment,
+        Include
+    }
+
+    public class AspRegion
+    {
+        public AspRegionType Type { get; set; }
+        public string Text { get; set; } = string.Empty;
+        public int Line { get; set; }
+
+        /// <summary>Populated only for Include regions: the raw file/virtual path attribute value.</summary>
+        public string? IncludePath { get; set; }
+        public bool IncludeIsVirtual { get; set; }
+    }
+
+    /// <summary>
+    /// Splits a raw classic ASP file into an ordered list of regions: literal HTML,
+    /// `&lt;% code %&gt;` blocks, `&lt;%= expr %&gt;` output expressions, `&lt;%@ ... %&gt;` directives,
+    /// `&lt;%-- ... --%&gt;` server comments, and `&lt;!--#include ... --&gt;` directives.
+    ///
+    /// Classic ASP ambiguities handled here specifically:
+    ///  - a `%&gt;` that appears *inside* a VBScript string literal inside a code block
+    ///    (e.g. `&lt;% s = "50%&gt;" %&gt;`) must not be treated as the block terminator, so the
+    ///    scanner tracks string-literal state (VBScript escapes quotes by doubling them)
+    ///    while looking for the real close tag.
+    ///  - `&lt;!--#include file="x.asp"--&gt;` / `virtual="/x.asp"` looks like an ordinary HTML
+    ///    comment and must be distinguished from one before being emitted as literal Html.
+    ///  - matching is case-insensitive and tolerant of extra whitespace around `=`,
+    ///    since real-world ASP markup is inconsistent about both.
+    /// </summary>
     public class AspLexer
     {
-        public void Tokenize(string content)
+        private static readonly Regex IncludeRegex = new(
+            @"<!--\s*#include\s+(file|virtual)\s*=\s*[""']([^""']+)[""']\s*-->",
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public List<AspRegion> Tokenize(string content)
         {
-            // Tokenize logic for ASP <% %> tags
+            var regions = new List<AspRegion>();
+            if (string.IsNullOrEmpty(content)) return regions;
+
+            int index = 0;
+            int line = 1;
+            var htmlBuffer = new StringBuilder();
+
+            void FlushHtml()
+            {
+                if (htmlBuffer.Length == 0) return;
+                var text = htmlBuffer.ToString();
+                var split = ExtractIncludes(text, line - CountNewlines(text));
+                if (split is null)
+                {
+                    regions.Add(new AspRegion { Type = AspRegionType.Html, Text = text, Line = line });
+                }
+                else
+                {
+                    regions.AddRange(split);
+                }
+                htmlBuffer.Clear();
+            }
+
+            while (index < content.Length)
+            {
+                if (content[index] == '<' && index + 1 < content.Length && content[index + 1] == '%')
+                {
+                    FlushHtml();
+
+                    int tagStart = index;
+                    int cursor = index + 2;
+                    AspRegionType type = AspRegionType.CodeBlock;
+
+                    if (cursor + 1 < content.Length && content[cursor] == '-' && content[cursor + 1] == '-')
+                    {
+                        type = AspRegionType.ServerComment;
+                        cursor += 2;
+                    }
+                    else if (cursor < content.Length && content[cursor] == '=')
+                    {
+                        type = AspRegionType.OutputExpression;
+                        cursor += 1;
+                    }
+                    else if (cursor < content.Length && content[cursor] == '@')
+                    {
+                        type = AspRegionType.Directive;
+                        cursor += 1;
+                    }
+
+                    string closer = type == AspRegionType.ServerComment ? "--%>" : "%>";
+                    int end = FindBlockEnd(content, cursor, closer);
+                    string inner = end >= cursor ? content.Substring(cursor, end - cursor) : content.Substring(cursor);
+
+                    regions.Add(new AspRegion { Type = type, Text = inner.Trim(), Line = line });
+
+                    line += CountNewlines(content.Substring(tagStart, (end < 0 ? content.Length : end + closer.Length) - tagStart));
+                    index = end < 0 ? content.Length : end + closer.Length;
+                    continue;
+                }
+
+                if (content[index] == '\n') line++;
+                htmlBuffer.Append(content[index]);
+                index++;
+            }
+
+            FlushHtml();
+            return regions;
+        }
+
+        /// <summary>
+        /// Finds the index of `closer` in `content` starting at `from`, treating text
+        /// inside VBScript double-quoted string literals (with `""` escaping) as opaque
+        /// so a stray `%&gt;` embedded in a string doesn't prematurely end the code block.
+        /// </summary>
+        private static int FindBlockEnd(string content, int from, string closer)
+        {
+            bool inString = false;
+            int i = from;
+            while (i < content.Length)
+            {
+                char c = content[i];
+                if (c == '"')
+                {
+                    if (inString && i + 1 < content.Length && content[i + 1] == '"')
+                    {
+                        i += 2;
+                        continue;
+                    }
+                    inString = !inString;
+                    i++;
+                    continue;
+                }
+
+                if (!inString && c == closer[0] && i + closer.Length <= content.Length &&
+                    content.Substring(i, closer.Length) == closer)
+                {
+                    return i;
+                }
+
+                i++;
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// A run of literal HTML can itself contain `&lt;!--#include--&gt;` directives, which are
+        /// not real HTML comments even though they're spelled like one. Splits such a run
+        /// into Html/Include regions in order; returns null when there are none, in which
+        /// case the caller keeps the original single Html region.
+        /// </summary>
+        private static List<AspRegion>? ExtractIncludes(string html, int startLine)
+        {
+            var matches = IncludeRegex.Matches(html);
+            if (matches.Count == 0) return null;
+
+            var result = new List<AspRegion>();
+            int cursor = 0;
+            int line = startLine;
+            foreach (Match m in matches)
+            {
+                if (m.Index > cursor)
+                {
+                    var before = html.Substring(cursor, m.Index - cursor);
+                    result.Add(new AspRegion { Type = AspRegionType.Html, Text = before, Line = line });
+                    line += CountNewlines(before);
+                }
+
+                result.Add(new AspRegion
+                {
+                    Type = AspRegionType.Include,
+                    Text = m.Value,
+                    Line = line,
+                    IncludePath = m.Groups[2].Value,
+                    IncludeIsVirtual = string.Equals(m.Groups[1].Value, "virtual", StringComparison.OrdinalIgnoreCase)
+                });
+                line += CountNewlines(m.Value);
+                cursor = m.Index + m.Length;
+            }
+
+            if (cursor < html.Length)
+            {
+                result.Add(new AspRegion { Type = AspRegionType.Html, Text = html.Substring(cursor), Line = line });
+            }
+
+            return result;
+        }
+
+        private static int CountNewlines(string text)
+        {
+            int count = 0;
+            foreach (var c in text) if (c == '\n') count++;
+            return count;
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/AspParser/AspParser.cs
+++ b/src/Phase5-ASPtoAngular/AspParser/AspParser.cs
@@ -1,10 +1,102 @@
 namespace BLML.Phase5ASPtoAngular.AspParser
 {
+    /// <summary>
+    /// Top-level entry point for classic ASP parsing: lexes a page into regions,
+    /// resolves `#include` directives when a file path/app root is available, then
+    /// builds one combined statement stream (see <see cref="VBScriptParser"/>) so that
+    /// HTML written inside VBScript control-flow blocks lands in the right place in
+    /// the resulting AST instead of being flattened after it.
+    /// </summary>
     public class AspParser
     {
-        public void Parse(string content)
+        private readonly AspLexer _lexer = new();
+
+        public AspPageNode Parse(string content, string? filePath = null, string? applicationRoot = null)
         {
-            // Parse logic for ASP structure
+            var page = new AspPageNode { FilePath = filePath ?? string.Empty };
+            var finalContent = content;
+
+            if (filePath != null && applicationRoot != null)
+            {
+                var resolver = new IncludeFileResolver(applicationRoot);
+                var resolved = resolver.ResolveIncludes(content, filePath);
+                finalContent = resolved.Content;
+                page.ResolvedIncludePaths.AddRange(resolved.ResolvedFiles);
+                page.ParseWarnings.AddRange(resolved.Warnings);
+            }
+
+            var regions = _lexer.Tokenize(finalContent);
+            var vbParser = new VBScriptParser();
+            var stream = new List<AspStreamItem>();
+
+            foreach (var region in regions)
+            {
+                switch (region.Type)
+                {
+                    case AspRegionType.Directive:
+                        page.Directives.Add(ParseDirective(region.Text));
+                        break;
+
+                    case AspRegionType.ServerComment:
+                        // Server-side comments never reach the output; nothing to add to the stream.
+                        break;
+
+                    case AspRegionType.Html:
+                        if (region.Text.Length > 0)
+                        {
+                            stream.Add(AspStreamItem.ForLeaf(new HtmlOutputStatementNode { Html = region.Text }));
+                        }
+                        break;
+
+                    case AspRegionType.OutputExpression:
+                        var exprNode = vbParser.ParseExpressionText(region.Text);
+                        stream.Add(AspStreamItem.ForLeaf(new AspOutputExpressionStatementNode
+                        {
+                            Expression = exprNode,
+                            RawExpression = region.Text
+                        }));
+                        break;
+
+                    case AspRegionType.CodeBlock:
+                        AppendCodeTokens(stream, region.Text);
+                        break;
+
+                    case AspRegionType.Include:
+                        // Only reachable when Parse() was called without filePath/applicationRoot
+                        // (so includes couldn't be resolved) - fall back to treating it as inert text.
+                        page.ParseWarnings.Add($"Include '{region.IncludePath}' left unresolved (no application root supplied).");
+                        break;
+                }
+            }
+
+            page.Statements.AddRange(vbParser.ParseProgram(stream));
+            page.ParseWarnings.AddRange(vbParser.Warnings);
+            return page;
+        }
+
+        private static void AppendCodeTokens(List<AspStreamItem> stream, string codeText)
+        {
+            var tokens = new VbScriptTokenizer().Tokenize(codeText);
+            foreach (var t in tokens)
+            {
+                if (t.Kind == VbsTokenKind.EndOfFile) continue;
+                stream.Add(AspStreamItem.ForToken(t));
+            }
+            // A `%>...<%` tag boundary is always at least as strong a statement break as a
+            // physical newline (see class remarks) - without this, `<% rs.MoveNext %><% x = 1 %>`
+            // would misparse as a parenless call to MoveNext with `x` as its argument.
+            stream.Add(AspStreamItem.ForToken(new VbsToken { Kind = VbsTokenKind.NewLine, Value = "\n" }));
+        }
+
+        private static AspDirective ParseDirective(string text)
+        {
+            var directive = new AspDirective();
+            foreach (System.Text.RegularExpressions.Match m in
+                     System.Text.RegularExpressions.Regex.Matches(text, "(\\w+)\\s*=\\s*\"([^\"]*)\""))
+            {
+                directive.Attributes[m.Groups[1].Value] = m.Groups[2].Value;
+            }
+            return directive;
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/AspParser/GlobalAsaParser.cs
+++ b/src/Phase5-ASPtoAngular/AspParser/GlobalAsaParser.cs
@@ -1,0 +1,99 @@
+using BLML.Phase1Foundation.AST;
+
+namespace BLML.Phase5ASPtoAngular.AspParser
+{
+    /// <summary>One `&lt;OBJECT RUNAT=Server SCOPE=... ID=... PROGID/CLASSID=...&gt;` declaration.</summary>
+    public class GlobalAsaObjectDeclaration
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Scope { get; set; } = string.Empty; // Session or Application
+        public string? ProgId { get; set; }
+        public string? ClassId { get; set; }
+    }
+
+    public class GlobalAsaPageNode
+    {
+        public MethodDeclarationNode? ApplicationOnStart { get; set; }
+        public MethodDeclarationNode? ApplicationOnEnd { get; set; }
+        public MethodDeclarationNode? SessionOnStart { get; set; }
+        public MethodDeclarationNode? SessionOnEnd { get; set; }
+        public List<MethodDeclarationNode> OtherSubs { get; } = new();
+        public List<GlobalAsaObjectDeclaration> Objects { get; } = new();
+        public List<string> Warnings { get; } = new();
+    }
+
+    /// <summary>
+    /// Parses Global.asa: the four well-known application/session lifecycle events
+    /// (each a plain `Sub ... End Sub` using the same VBScript grammar as page code,
+    /// so it's parsed with the same <see cref="VBScriptParser"/>), plus `&lt;OBJECT
+    /// RUNAT=Server&gt;` declarations that make a COM component available for the whole
+    /// application/session scope. `&lt;SCRIPT LANGUAGE="VBScript" RUNAT="Server"&gt;` wrapper
+    /// tags are stripped before parsing since they're markup, not VBScript.
+    /// </summary>
+    public class GlobalAsaParser
+    {
+        private static readonly System.Text.RegularExpressions.Regex ScriptBlockRegex = new(
+            "<script[^>]*runat\\s*=\\s*[\"']?server[\"']?[^>]*>(.*?)</script>",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase | System.Text.RegularExpressions.RegexOptions.Singleline);
+
+        private static readonly System.Text.RegularExpressions.Regex ObjectTagRegex = new(
+            "<object\\b([^>]*)>",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        private static readonly System.Text.RegularExpressions.Regex AttrRegex = new(
+            "(\\w+)\\s*=\\s*(?:\"([^\"]*)\"|'([^']*)'|([^\\s>]+))",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        public GlobalAsaPageNode Parse(string content)
+        {
+            var result = new GlobalAsaPageNode();
+
+            foreach (System.Text.RegularExpressions.Match m in ObjectTagRegex.Matches(content))
+            {
+                result.Objects.Add(ParseObjectTag(m.Groups[1].Value));
+            }
+
+            var vbParser = new VBScriptParser();
+            var scriptMatches = ScriptBlockRegex.Matches(content);
+            var codeToParse = scriptMatches.Count > 0
+                ? string.Join("\n", scriptMatches.Select(m => m.Groups[1].Value))
+                : content; // tolerate a Global.asa with bare Subs and no <script> wrapper
+
+            var statements = vbParser.ParseCodeText(codeToParse);
+            result.Warnings.AddRange(vbParser.Warnings);
+
+            foreach (var stmt in statements)
+            {
+                if (stmt is not MethodDeclarationNode method) continue;
+                switch (method.Name.ToLowerInvariant())
+                {
+                    case "application_onstart": result.ApplicationOnStart = method; break;
+                    case "application_onend": result.ApplicationOnEnd = method; break;
+                    case "session_onstart": result.SessionOnStart = method; break;
+                    case "session_onend": result.SessionOnEnd = method; break;
+                    default: result.OtherSubs.Add(method); break;
+                }
+            }
+
+            return result;
+        }
+
+        private static GlobalAsaObjectDeclaration ParseObjectTag(string attrText)
+        {
+            var decl = new GlobalAsaObjectDeclaration();
+            foreach (System.Text.RegularExpressions.Match m in AttrRegex.Matches(attrText))
+            {
+                var name = m.Groups[1].Value.ToLowerInvariant();
+                var value = m.Groups[2].Success ? m.Groups[2].Value : m.Groups[3].Success ? m.Groups[3].Value : m.Groups[4].Value;
+                switch (name)
+                {
+                    case "id": decl.Id = value; break;
+                    case "scope": decl.Scope = value; break;
+                    case "progid": decl.ProgId = value; break;
+                    case "classid": decl.ClassId = value; break;
+                }
+            }
+            return decl;
+        }
+    }
+}

--- a/src/Phase5-ASPtoAngular/AspParser/IncludeFileResolver.cs
+++ b/src/Phase5-ASPtoAngular/AspParser/IncludeFileResolver.cs
@@ -1,0 +1,102 @@
+namespace BLML.Phase5ASPtoAngular.AspParser
+{
+    /// <summary>
+    /// Resolves `&lt;!--#include file="x.asp"--&gt;` / `virtual="/x.asp"` directives.
+    /// `file=` is relative to the including file's own directory (and can use `../`);
+    /// `virtual=` is relative to the site's application root. Detects circular includes
+    /// rather than recursing forever, since a real classic-ASP codebase (e.g. a shared
+    /// header/footer pair that both pull in a common nav file) can easily form a cycle
+    /// if someone slips up.
+    /// </summary>
+    public class IncludeFileResolver
+    {
+        private readonly string _applicationRoot;
+
+        public IncludeFileResolver(string applicationRoot)
+        {
+            _applicationRoot = applicationRoot;
+        }
+
+        public class ResolveResult
+        {
+            public string Content { get; set; } = string.Empty;
+            public List<string> ResolvedFiles { get; } = new();
+            public List<string> Warnings { get; } = new();
+        }
+
+        public ResolveResult ResolveIncludes(string content, string currentFilePath)
+        {
+            var result = new ResolveResult();
+            var visiting = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { NormalizePath(currentFilePath) };
+            result.Content = ResolveRecursive(content, currentFilePath, visiting, result);
+            return result;
+        }
+
+        private string ResolveRecursive(string content, string currentFilePath, HashSet<string> visiting, ResolveResult result)
+        {
+            var lexer = new AspLexer();
+            var regions = lexer.Tokenize(content);
+            var includeRegions = regions.Where(r => r.Type == AspRegionType.Include).ToList();
+            if (includeRegions.Count == 0) return content;
+
+            var sb = new System.Text.StringBuilder();
+            foreach (var region in regions)
+            {
+                if (region.Type != AspRegionType.Include)
+                {
+                    sb.Append(RegionToText(region));
+                    continue;
+                }
+
+                var resolvedPath = ResolvePath(region, currentFilePath);
+                if (resolvedPath is null || !File.Exists(resolvedPath))
+                {
+                    result.Warnings.Add($"Could not resolve include '{region.IncludePath}' referenced from '{currentFilePath}'.");
+                    continue;
+                }
+
+                var normalized = NormalizePath(resolvedPath);
+                if (visiting.Contains(normalized))
+                {
+                    result.Warnings.Add($"Circular include detected: '{region.IncludePath}' referenced from '{currentFilePath}'.");
+                    continue;
+                }
+
+                var includedContent = File.ReadAllText(resolvedPath);
+                result.ResolvedFiles.Add(resolvedPath);
+                visiting.Add(normalized);
+                sb.Append(ResolveRecursive(includedContent, resolvedPath, visiting, result));
+                visiting.Remove(normalized);
+            }
+
+            return sb.ToString();
+        }
+
+        private string? ResolvePath(AspRegion region, string currentFilePath)
+        {
+            if (string.IsNullOrEmpty(region.IncludePath)) return null;
+
+            if (region.IncludeIsVirtual)
+            {
+                var relative = region.IncludePath.TrimStart('/', '\\');
+                return Path.Combine(_applicationRoot, relative);
+            }
+
+            var baseDir = Path.GetDirectoryName(currentFilePath) ?? _applicationRoot;
+            return Path.GetFullPath(Path.Combine(baseDir, region.IncludePath));
+        }
+
+        private static string NormalizePath(string path) => Path.GetFullPath(path).TrimEnd('\\', '/').ToLowerInvariant();
+
+        /// <summary>Reconstructs the original markup for a non-include region so re-splicing doesn't lose text.</summary>
+        private static string RegionToText(AspRegion region) => region.Type switch
+        {
+            AspRegionType.Html => region.Text,
+            AspRegionType.OutputExpression => $"<%={region.Text}%>",
+            AspRegionType.Directive => $"<%@{region.Text}%>",
+            AspRegionType.ServerComment => $"<%--{region.Text}--%>",
+            AspRegionType.CodeBlock => $"<%{region.Text}%>",
+            _ => region.Text
+        };
+    }
+}

--- a/src/Phase5-ASPtoAngular/AspParser/VBScriptParser.cs
+++ b/src/Phase5-ASPtoAngular/AspParser/VBScriptParser.cs
@@ -1,10 +1,664 @@
+using BLML.Phase1Foundation.AST;
+
 namespace BLML.Phase5ASPtoAngular.AspParser
 {
+    public enum AspStreamItemKind { Code, Leaf }
+
+    /// <summary>
+    /// One item in the combined per-page token stream: either a VBScript code token,
+    /// or a pre-built leaf statement (an Html or `&lt;%= %&gt;` output chunk) sitting where it
+    /// was physically written in the .asp file. Feeding both kinds through the same
+    /// statement parser is what lets `&lt;% If x Then %&gt;html&lt;% End If %&gt;` nest the html
+    /// correctly inside the If's body instead of after it.
+    /// </summary>
+    public class AspStreamItem
+    {
+        public AspStreamItemKind Kind { get; set; }
+        public VbsToken? Token { get; set; }
+        public StatementNode? Leaf { get; set; }
+
+        public static AspStreamItem ForToken(VbsToken t) => new() { Kind = AspStreamItemKind.Code, Token = t };
+        public static AspStreamItem ForLeaf(StatementNode n) => new() { Kind = AspStreamItemKind.Leaf, Leaf = n };
+    }
+
+    /// <summary>
+    /// Recursive-descent parser for classic-ASP VBScript. Scoped to the patterns that
+    /// actually show up in real classic ASP pages rather than the full VBScript grammar:
+    ///  - no `Class ... End Class`, no user-defined `Type`, no `Property` blocks
+    ///    (uncommon inline in .asp pages; when Global.asa needs Sub bodies it reuses
+    ///    the same statement parser used here)
+    ///  - `Select Case` supports comma-separated value lists and `Case Else` only -
+    ///    VBScript itself doesn't support `Case 1 To 10` / `Case Is > 5` (those are
+    ///    VBA/VB6-only), so there's nothing being left out here
+    ///  - parenless statement calls (`Response.Write "x", y` with no parens around the
+    ///    argument list - a real VB-family ambiguity) are supported heuristically: the
+    ///    parser always consumes an adjacent `(...)` as a call's arguments, then treats
+    ///    any further comma-separated expressions up to the next line break as
+    ///    additional arguments
+    /// </summary>
     public class VBScriptParser
     {
-        public void ParseScript(string script)
+        public List<string> Warnings { get; } = new();
+
+        private List<AspStreamItem> _items = new();
+        private int _pos;
+
+        public List<StatementNode> ParseProgram(List<AspStreamItem> stream)
         {
-            // VBScript parsing logic tailored for ASP server-side script blocks
+            _items = stream;
+            _pos = 0;
+            var statements = new List<StatementNode>();
+            SkipNewLines();
+            while (!AtCodeEnd())
+            {
+                var stmt = ParseStatement();
+                if (stmt != null) statements.Add(stmt);
+                SkipNewLines();
+            }
+            return statements;
         }
+
+        public ExpressionNode ParseExpressionText(string text)
+        {
+            var tokens = new VbScriptTokenizer().Tokenize(text);
+            _items = tokens.Where(t => t.Kind != VbsTokenKind.NewLine).Select(AspStreamItem.ForToken).ToList();
+            _pos = 0;
+            return ParseExpression();
+        }
+
+        public List<StatementNode> ParseCodeText(string code)
+        {
+            var tokens = new VbScriptTokenizer().Tokenize(code);
+            return ParseProgram(tokens.Select(AspStreamItem.ForToken).ToList());
+        }
+
+        // ----- stream helpers -----
+
+        private AspStreamItem Current => _pos < _items.Count ? _items[_pos] : AspStreamItem.ForToken(new VbsToken { Kind = VbsTokenKind.EndOfFile });
+        private bool AtCodeEnd() => Current.Kind == AspStreamItemKind.Code && Current.Token!.Kind == VbsTokenKind.EndOfFile;
+        private bool IsLeaf() => Current.Kind == AspStreamItemKind.Leaf;
+        private bool IsNewLine() => Current.Kind == AspStreamItemKind.Code && Current.Token!.Kind == VbsTokenKind.NewLine;
+
+        private bool IsKeyword(string word) => Current.Kind == AspStreamItemKind.Code && (Current.Token!.IsKeyword(word));
+        private bool IsOperator(string op) => Current.Kind == AspStreamItemKind.Code && Current.Token!.IsOperator(op);
+
+        private VbsToken Advance()
+        {
+            var t = Current.Kind == AspStreamItemKind.Code ? Current.Token! : new VbsToken { Kind = VbsTokenKind.Identifier, Value = string.Empty };
+            _pos++;
+            return t;
+        }
+
+        private void SkipNewLines()
+        {
+            while (IsNewLine()) _pos++;
+        }
+
+        private void ExpectKeyword(string word)
+        {
+            if (!IsKeyword(word)) Warnings.Add($"Expected '{word}' at token '{(Current.Kind == AspStreamItemKind.Code ? Current.Token!.Value : "<html>")}'.");
+            else _pos++;
+        }
+
+        private void ExpectOperator(string op)
+        {
+            if (!IsOperator(op)) Warnings.Add($"Expected '{op}' at token '{(Current.Kind == AspStreamItemKind.Code ? Current.Token!.Value : "<html>")}'.");
+            else _pos++;
+        }
+
+        // ----- statements -----
+
+        public StatementNode? ParseStatement()
+        {
+            if (IsLeaf())
+            {
+                var leaf = Current.Leaf!;
+                _pos++;
+                return leaf;
+            }
+
+            if (IsKeyword("Dim") || IsKeyword("Public") || IsKeyword("Private")) return ParseDeclaration();
+            if (IsKeyword("Const")) return ParseConst();
+            if (IsKeyword("ReDim")) return ParseReDim();
+            if (IsKeyword("If")) return ParseIf();
+            if (IsKeyword("For")) return ParseFor();
+            if (IsKeyword("While")) return ParseWhile();
+            if (IsKeyword("Do")) return ParseDoLoop();
+            if (IsKeyword("Select")) return ParseSelectCase();
+            if (IsKeyword("Sub")) return ParseSubOrFunction(isFunction: false);
+            if (IsKeyword("Function")) return ParseSubOrFunction(isFunction: true);
+            if (IsKeyword("Exit")) return ParseExit();
+            if (IsKeyword("On")) return ParseOnError();
+            if (IsKeyword("Call")) return ParseCall();
+            if (IsKeyword("Set")) return ParseAssignmentOrCall(isSet: true);
+
+            return ParseAssignmentOrCall(isSet: false);
+        }
+
+        private BlockNode ParseBlockUntil(params string[] terminators)
+        {
+            var block = new BlockNode();
+            SkipNewLines();
+            while (!AtCodeEnd() && !NextIsAnyKeyword(terminators))
+            {
+                var stmt = ParseStatement();
+                if (stmt != null) block.Statements.Add(stmt);
+                SkipNewLines();
+            }
+            return block;
+        }
+
+        private bool NextIsAnyKeyword(string[] words)
+        {
+            foreach (var w in words) if (IsKeyword(w)) return true;
+            return false;
+        }
+
+        private StatementNode ParseDeclaration()
+        {
+            var accessibility = IsKeyword("Public") ? VB6Accessibility.Public : IsKeyword("Private") ? VB6Accessibility.Private : VB6Accessibility.Private;
+            Advance(); // Dim/Public/Private
+            var group = new VariableDeclarationGroupNode();
+            do
+            {
+                if (IsOperator(",")) Advance();
+                if (Current.Kind != AspStreamItemKind.Code || Current.Token!.Kind != VbsTokenKind.Identifier)
+                {
+                    Warnings.Add("Expected variable name in declaration.");
+                    break;
+                }
+                var name = Advance().Value;
+                bool isArray = false;
+                if (IsOperator("("))
+                {
+                    isArray = true;
+                    Advance();
+                    while (!IsOperator(")") && !AtCodeEnd()) Advance();
+                    if (IsOperator(")")) Advance();
+                }
+                group.Declarations.Add(new VariableDeclarationNode { Name = name, Accessibility = accessibility, IsArray = isArray });
+            } while (IsOperator(","));
+            return group;
+        }
+
+        private StatementNode ParseConst()
+        {
+            Advance(); // Const
+            var group = new VariableDeclarationGroupNode();
+            do
+            {
+                if (IsOperator(",")) Advance();
+                var name = Advance().Value;
+                ExpectOperator("=");
+                var value = ParseExpression();
+                group.Declarations.Add(new VariableDeclarationNode { Name = name, InitialValue = ExpressionToText(value) });
+            } while (IsOperator(","));
+            return group;
+        }
+
+        private StatementNode ParseReDim()
+        {
+            Advance(); // ReDim
+            bool preserve = false;
+            if (IsKeyword("Preserve")) { preserve = true; Advance(); }
+            var name = Advance().Value;
+            var node = new ReDimStatementNode { VariableName = name, Preserve = preserve };
+            ExpectOperator("(");
+            while (!IsOperator(")") && !AtCodeEnd())
+            {
+                node.NewDimensions.Add(ParseExpression());
+                if (IsOperator(",")) Advance(); else break;
+            }
+            ExpectOperator(")");
+            return node;
+        }
+
+        /// <summary>
+        /// Handles the single-line-vs-block ambiguity: `If cond Then` immediately
+        /// followed by a NewLine is the block form (terminated by ElseIf/Else/End If);
+        /// followed by anything else on the same line is the single-line form, which
+        /// has no End If and whose Else branch (if any) is also single-statement.
+        /// </summary>
+        private StatementNode ParseIf()
+        {
+            Advance(); // If
+            var condition = ParseExpression();
+            ExpectKeyword("Then");
+
+            if (IsNewLine())
+            {
+                var ifNode = new IfStatementNode { Condition = condition };
+                ifNode.TrueBlock = ParseBlockUntil("ElseIf", "Else", "End");
+
+                if (IsKeyword("ElseIf"))
+                {
+                    var elseBlock = new BlockNode();
+                    elseBlock.Statements.Add(ParseIf());
+                    ifNode.ElseBlock = elseBlock;
+                    return ifNode;
+                }
+
+                if (IsKeyword("Else"))
+                {
+                    Advance();
+                    ifNode.ElseBlock = ParseBlockUntil("End");
+                }
+
+                ExpectKeyword("End");
+                ExpectKeyword("If");
+                return ifNode;
+            }
+
+            // Single-line form: If cond Then stmt [Else stmt]
+            var single = new SingleLineIfStatementNode { Condition = condition };
+            single.ThenStatement = ParseSingleLineBody();
+            if (IsKeyword("Else"))
+            {
+                Advance();
+                single.ElseStatement = ParseSingleLineBody();
+            }
+            return single;
+        }
+
+        private StatementNode ParseSingleLineBody()
+        {
+            // A single-line If/Else body may itself contain multiple `:`-separated
+            // statements; ParseStatement/SkipNewLines already treat `:` as a line break,
+            // so collecting statements until the real end-of-line (or Else/EOF) covers it.
+            var stmt = ParseStatement();
+            return stmt ?? new ExpressionStatementNode { Expression = new LiteralExpressionNode { Value = string.Empty } };
+        }
+
+        private StatementNode ParseFor()
+        {
+            Advance(); // For
+            if (IsKeyword("Each"))
+            {
+                Advance();
+                var varName = Advance().Value;
+                ExpectKeyword("In");
+                var collection = ParseExpression();
+                // `For Each` has no single-line form in VBScript - the body always runs to a matching Next.
+                var node = new ForEachStatementNode { LoopVariable = varName, Collection = collection };
+                node.Body = ParseBlockUntil("Next");
+                ExpectKeyword("Next");
+                if (Current.Kind == AspStreamItemKind.Code && Current.Token!.Kind == VbsTokenKind.Identifier) Advance();
+                return node;
+            }
+            else
+            {
+                var loopVar = Advance().Value;
+                ExpectOperator("=");
+                var start = ParseExpression();
+                ExpectKeyword("To");
+                var end = ParseExpression();
+                ExpressionNode? step = null;
+                if (IsKeyword("Step")) { Advance(); step = ParseExpression(); }
+
+                var node = new ForStatementNode { LoopVariable = loopVar, StartValue = start, EndValue = end, StepValue = step };
+                node.Body = ParseBlockUntil("Next");
+                ExpectKeyword("Next");
+                if (Current.Kind == AspStreamItemKind.Code && Current.Token!.Kind == VbsTokenKind.Identifier) Advance();
+                return node;
+            }
+        }
+
+        private StatementNode ParseWhile()
+        {
+            Advance(); // While
+            var cond = ParseExpression();
+            var node = new WhileStatementNode { Condition = cond };
+            node.Body = ParseBlockUntil("Wend");
+            ExpectKeyword("Wend");
+            return node;
+        }
+
+        private StatementNode ParseDoLoop()
+        {
+            Advance(); // Do
+            bool isDoWhile = false, isUntil = false;
+            ExpressionNode? condition = null;
+
+            if (IsKeyword("While") || IsKeyword("Until"))
+            {
+                isDoWhile = true;
+                isUntil = IsKeyword("Until");
+                Advance();
+                condition = ParseExpression();
+            }
+
+            var node = new DoLoopStatementNode { IsDoWhile = isDoWhile, IsUntil = isUntil, Condition = condition };
+            node.Body = ParseBlockUntil("Loop");
+            ExpectKeyword("Loop");
+
+            if (!isDoWhile && (IsKeyword("While") || IsKeyword("Until")))
+            {
+                node.IsUntil = IsKeyword("Until");
+                Advance();
+                node.Condition = ParseExpression();
+            }
+            return node;
+        }
+
+        private StatementNode ParseSelectCase()
+        {
+            Advance(); // Select
+            ExpectKeyword("Case");
+            var testExpr = ParseExpression();
+            var node = new SelectCaseStatementNode { TestExpression = testExpr };
+            SkipNewLines();
+
+            while (IsKeyword("Case"))
+            {
+                Advance();
+                if (IsKeyword("Else"))
+                {
+                    Advance();
+                    node.CaseElseBlock = ParseBlockUntil("Case", "End");
+                    continue;
+                }
+
+                var clause = new CaseClauseNode();
+                clause.Values.Add(ParseExpression());
+                while (IsOperator(","))
+                {
+                    Advance();
+                    clause.Values.Add(ParseExpression());
+                }
+                clause.Body = ParseBlockUntil("Case", "End");
+                node.Cases.Add(clause);
+            }
+
+            ExpectKeyword("End");
+            ExpectKeyword("Select");
+            return node;
+        }
+
+        private StatementNode ParseSubOrFunction(bool isFunction)
+        {
+            Advance(); // Sub/Function
+            var name = Advance().Value;
+            var method = new MethodDeclarationNode { Name = name, IsFunction = isFunction };
+
+            if (IsOperator("("))
+            {
+                Advance();
+                while (!IsOperator(")") && !AtCodeEnd())
+                {
+                    bool byRef = true;
+                    if (IsKeyword("Byval")) { byRef = false; Advance(); }
+                    else if (IsKeyword("Byref")) { Advance(); }
+                    var pname = Advance().Value;
+                    method.Parameters.Add(new ParameterNode { Name = pname, IsByRef = byRef });
+                    if (IsOperator(",")) Advance(); else break;
+                }
+                ExpectOperator(")");
+            }
+
+            var terminator = isFunction ? "Function" : "Sub";
+            var block = ParseBlockUntil("End");
+            method.Body.AddRange(block.Statements);
+            ExpectKeyword("End");
+            ExpectKeyword(terminator);
+            return method;
+        }
+
+        private StatementNode ParseExit()
+        {
+            Advance(); // Exit
+            var kind = Advance().Value; // For/Do/Sub/Function
+            return new ExitStatementNode { ExitKind = kind };
+        }
+
+        private StatementNode ParseOnError()
+        {
+            Advance(); // On
+            ExpectKeyword("Error");
+            if (IsKeyword("Resume"))
+            {
+                Advance();
+                ExpectKeyword("Next");
+                return new OnErrorStatementNode { IsResumeNext = true };
+            }
+            ExpectKeyword("GoTo");
+            var target = Advance().Value; // usually "0"
+            return new OnErrorStatementNode { IsGoTo0 = target == "0", LabelName = target };
+        }
+
+        private StatementNode ParseCall()
+        {
+            Advance(); // Call
+            var expr = ParsePostfix(ParsePrimary());
+            return new CallStatementNode { Invocation = expr };
+        }
+
+        /// <summary>
+        /// Handles `target = expr`, `Set target = expr`, and bare statement invocations
+        /// (`rs.MoveNext`, `Response.Write "x", y` with no enclosing parens). See the
+        /// class-level remarks on the parenless-call heuristic.
+        /// </summary>
+        private StatementNode ParseAssignmentOrCall(bool isSet)
+        {
+            if (isSet) Advance(); // Set
+
+            var expr = ParsePostfix(ParsePrimary());
+
+            if (IsOperator("="))
+            {
+                Advance();
+                var value = ParseExpression();
+                return new AssignmentNode { Target = expr, Value = value };
+            }
+
+            var invocation = expr as InvocationExpressionNode ?? new InvocationExpressionNode { Target = expr };
+            if (!IsNewLine() && !AtCodeEnd() && !NextStartsBlockKeyword())
+            {
+                invocation.Arguments.Add(ParseExpression());
+                while (IsOperator(","))
+                {
+                    Advance();
+                    invocation.Arguments.Add(ParseExpression());
+                }
+            }
+            return new CallStatementNode { Invocation = invocation };
+        }
+
+        private bool NextStartsBlockKeyword()
+        {
+            string[] keywords = { "Else", "ElseIf", "End", "Next", "Loop", "Wend", "Case" };
+            return NextIsAnyKeyword(keywords);
+        }
+
+        // ----- expressions (precedence climbing) -----
+
+        public ExpressionNode ParseExpression() => ParseOr();
+
+        private ExpressionNode ParseOr()
+        {
+            var left = ParseAnd();
+            while (IsKeyword("Or") || IsKeyword("Xor") || IsKeyword("Eqv") || IsKeyword("Imp"))
+            {
+                var op = Advance().Value;
+                left = new BinaryExpressionNode { Left = left, Operator = op, Right = ParseAnd() };
+            }
+            return left;
+        }
+
+        private ExpressionNode ParseAnd()
+        {
+            var left = ParseNot();
+            while (IsKeyword("And"))
+            {
+                Advance();
+                left = new BinaryExpressionNode { Left = left, Operator = "And", Right = ParseNot() };
+            }
+            return left;
+        }
+
+        /// <summary>
+        /// `Not` is unary, but the shared AST only models <see cref="BinaryExpressionNode"/>.
+        /// By convention, unary operators are encoded with the operand in <c>Right</c> and
+        /// <c>Left</c> left null - callers generating code from this tree must check for
+        /// that (see AspExpressionToCSharp/AspExpressionToTypeScript's "Not" case).
+        /// </summary>
+        private ExpressionNode ParseNot()
+        {
+            if (IsKeyword("Not"))
+            {
+                Advance();
+                return new BinaryExpressionNode { Left = null!, Operator = "Not", Right = ParseNot() };
+            }
+            return ParseComparison();
+        }
+
+        private static readonly string[] ComparisonOps = { "=", "<>", "<", ">", "<=", ">=" };
+
+        private ExpressionNode ParseComparison()
+        {
+            var left = ParseConcat();
+            while ((Current.Kind == AspStreamItemKind.Code && Current.Token!.Kind == VbsTokenKind.Operator && ComparisonOps.Contains(Current.Token!.Value))
+                   || IsKeyword("Is") || IsKeyword("Like"))
+            {
+                var op = Advance().Value;
+                left = new BinaryExpressionNode { Left = left, Operator = op, Right = ParseConcat() };
+            }
+            return left;
+        }
+
+        private ExpressionNode ParseConcat()
+        {
+            var left = ParseAdditive();
+            while (IsOperator("&"))
+            {
+                Advance();
+                left = new BinaryExpressionNode { Left = left, Operator = "&", Right = ParseAdditive() };
+            }
+            return left;
+        }
+
+        private ExpressionNode ParseAdditive()
+        {
+            var left = ParseMultiplicative();
+            while (IsOperator("+") || IsOperator("-"))
+            {
+                var op = Advance().Value;
+                left = new BinaryExpressionNode { Left = left, Operator = op, Right = ParseMultiplicative() };
+            }
+            return left;
+        }
+
+        private ExpressionNode ParseMultiplicative()
+        {
+            var left = ParseUnary();
+            while (IsOperator("*") || IsOperator("/") || IsOperator("\\") || IsKeyword("Mod"))
+            {
+                var op = Advance().Value;
+                left = new BinaryExpressionNode { Left = left, Operator = op, Right = ParseUnary() };
+            }
+            return left;
+        }
+
+        private ExpressionNode ParseUnary()
+        {
+            if (IsOperator("-") || IsOperator("+"))
+            {
+                var op = Advance().Value;
+                return new BinaryExpressionNode { Left = new LiteralExpressionNode { Value = 0 }, Operator = op, Right = ParsePower() };
+            }
+            return ParsePower();
+        }
+
+        private ExpressionNode ParsePower()
+        {
+            var left = ParsePostfix(ParsePrimary());
+            if (IsOperator("^"))
+            {
+                Advance();
+                left = new BinaryExpressionNode { Left = left, Operator = "^", Right = ParseUnary() };
+            }
+            return left;
+        }
+
+        private ExpressionNode ParsePostfix(ExpressionNode expr)
+        {
+            while (true)
+            {
+                if (IsOperator("."))
+                {
+                    Advance();
+                    var member = Advance().Value;
+                    expr = new BinaryExpressionNode { Left = expr, Operator = ".", Right = new IdentifierExpressionNode { Name = member } };
+                    continue;
+                }
+
+                if (IsOperator("("))
+                {
+                    Advance();
+                    var invocation = new InvocationExpressionNode { Target = expr };
+                    while (!IsOperator(")") && !AtCodeEnd())
+                    {
+                        invocation.Arguments.Add(ParseExpression());
+                        if (IsOperator(",")) Advance(); else break;
+                    }
+                    ExpectOperator(")");
+                    expr = invocation;
+                    continue;
+                }
+
+                break;
+            }
+            return expr;
+        }
+
+        private ExpressionNode ParsePrimary()
+        {
+            if (Current.Kind != AspStreamItemKind.Code)
+            {
+                Warnings.Add("Expected expression but found embedded HTML/output.");
+                return new LiteralExpressionNode { Value = string.Empty };
+            }
+
+            var token = Current.Token!;
+
+            if (token.Kind == VbsTokenKind.String) { Advance(); return new LiteralExpressionNode { Value = token.Value }; }
+            if (token.Kind == VbsTokenKind.Number)
+            {
+                Advance();
+                return new LiteralExpressionNode { Value = token.Value.Contains('.') ? double.Parse(token.Value) : (object)long.Parse(token.Value) };
+            }
+            if (token.IsKeyword("True")) { Advance(); return new LiteralExpressionNode { Value = true }; }
+            if (token.IsKeyword("False")) { Advance(); return new LiteralExpressionNode { Value = false }; }
+            if (token.IsKeyword("Nothing") || token.IsKeyword("Null") || token.IsKeyword("Empty")) { Advance(); return new LiteralExpressionNode { Value = null! }; }
+
+            if (token.IsOperator("("))
+            {
+                Advance();
+                var inner = ParseExpression();
+                ExpectOperator(")");
+                return inner;
+            }
+
+            if (token.IsKeyword("Not"))
+            {
+                return ParseNot();
+            }
+
+            if (token.Kind == VbsTokenKind.Identifier || token.Kind == VbsTokenKind.Keyword)
+            {
+                Advance();
+                return new IdentifierExpressionNode { Name = token.Value };
+            }
+
+            Warnings.Add($"Unexpected token '{token.Value}' while parsing an expression.");
+            Advance();
+            return new LiteralExpressionNode { Value = string.Empty };
+        }
+
+        private static string ExpressionToText(ExpressionNode expr) => expr switch
+        {
+            LiteralExpressionNode lit => lit.Value?.ToString() ?? "",
+            IdentifierExpressionNode id => id.Name,
+            _ => expr.GetType().Name
+        };
     }
 }

--- a/src/Phase5-ASPtoAngular/AspParser/VbScriptTokenizer.cs
+++ b/src/Phase5-ASPtoAngular/AspParser/VbScriptTokenizer.cs
@@ -1,0 +1,224 @@
+using System.Text;
+
+namespace BLML.Phase5ASPtoAngular.AspParser
+{
+    public enum VbsTokenKind
+    {
+        Keyword,
+        Identifier,
+        String,
+        Number,
+        Operator,
+        NewLine,
+        EndOfFile
+    }
+
+    public class VbsToken
+    {
+        public VbsTokenKind Kind { get; set; }
+        public string Value { get; set; } = string.Empty;
+        public int Line { get; set; }
+
+        public bool IsKeyword(string word) => Kind == VbsTokenKind.Keyword && string.Equals(Value, word, StringComparison.OrdinalIgnoreCase);
+        public bool IsOperator(string op) => Kind == VbsTokenKind.Operator && Value == op;
+    }
+
+    /// <summary>
+    /// Tokenizes classic-ASP-flavored VBScript code (the text found inside `&lt;% %&gt;`
+    /// blocks). Unlike <see cref="BLML.Phase1Foundation.Lexer.VB6Lexer"/>, this keeps
+    /// explicit NewLine tokens (collapsing `_` line-continuations) because VBScript's
+    /// single-line `If x Then y = 1` vs. block `If x Then` / ... / `End If` forms are
+    /// only distinguishable by whether a newline follows `Then` - a genuine classic-ASP
+    /// ambiguity that a newline-blind token stream can't resolve.
+    /// </summary>
+    public class VbScriptTokenizer
+    {
+        private static readonly HashSet<string> Keywords = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "And", "As", "Byref", "Byval", "Call", "Case", "Class", "Const", "Dim", "Do",
+            "Each", "Else", "ElseIf", "Empty", "End", "Eqv", "Erase", "Error", "Exit",
+            "False", "For", "Function", "Get", "GoTo", "If", "Imp", "In", "Is", "Let",
+            "Like", "Loop", "Me", "Mod", "New", "Next", "Not", "Nothing", "Null", "On",
+            "Option", "Or", "Preserve", "Private", "Property", "Public", "ReDim",
+            "Rem", "Resume", "Select", "Set", "Step", "Sub", "Then", "To", "True",
+            "Until", "Wend", "While", "With", "Xor"
+        };
+
+        public static bool IsKeyword(string identifier) => Keywords.Contains(identifier);
+
+        public List<VbsToken> Tokenize(string code)
+        {
+            var tokens = new List<VbsToken>();
+            int i = 0;
+            int line = 1;
+            bool lineHasContent = false;
+
+            void EmitNewLineIfNeeded()
+            {
+                if (lineHasContent)
+                {
+                    tokens.Add(new VbsToken { Kind = VbsTokenKind.NewLine, Value = "\n", Line = line });
+                }
+            }
+
+            while (i < code.Length)
+            {
+                char c = code[i];
+
+                if (c == '\r') { i++; continue; }
+
+                if (c == '\n')
+                {
+                    EmitNewLineIfNeeded();
+                    lineHasContent = false;
+                    line++;
+                    i++;
+                    continue;
+                }
+
+                if (c == ' ' || c == '\t') { i++; continue; }
+
+                // Line continuation: a lone `_` immediately before end-of-line suppresses the newline.
+                if (c == '_' && LooksLikeLineContinuation(code, i))
+                {
+                    i++;
+                    while (i < code.Length && (code[i] == ' ' || code[i] == '\t')) i++;
+                    if (i < code.Length && code[i] == '\r') i++;
+                    if (i < code.Length && code[i] == '\n') { i++; line++; }
+                    continue;
+                }
+
+                if (c == '\'' || StartsWithWord(code, i, "Rem"))
+                {
+                    // Comment: skip to end of line (do not emit a token; the comment carries no semantics we act on).
+                    while (i < code.Length && code[i] != '\n') i++;
+                    continue;
+                }
+
+                if (c == '"')
+                {
+                    tokens.Add(new VbsToken { Kind = VbsTokenKind.String, Value = ReadString(code, ref i), Line = line });
+                    lineHasContent = true;
+                    continue;
+                }
+
+                if (char.IsDigit(c) || (c == '.' && i + 1 < code.Length && char.IsDigit(code[i + 1])))
+                {
+                    tokens.Add(new VbsToken { Kind = VbsTokenKind.Number, Value = ReadNumber(code, ref i), Line = line });
+                    lineHasContent = true;
+                    continue;
+                }
+
+                if (char.IsLetter(c) || c == '_')
+                {
+                    var word = ReadIdentifier(code, ref i);
+                    tokens.Add(new VbsToken
+                    {
+                        Kind = IsKeyword(word) ? VbsTokenKind.Keyword : VbsTokenKind.Identifier,
+                        Value = word,
+                        Line = line
+                    });
+                    lineHasContent = true;
+                    continue;
+                }
+
+                var op = ReadOperator(code, ref i);
+                if (op != null)
+                {
+                    tokens.Add(new VbsToken { Kind = VbsTokenKind.Operator, Value = op, Line = line });
+                    lineHasContent = true;
+                    // A colon is an explicit same-line statement separator, semantically like a newline.
+                    if (op == ":")
+                    {
+                        tokens.Add(new VbsToken { Kind = VbsTokenKind.NewLine, Value = ":", Line = line });
+                        lineHasContent = false;
+                    }
+                    continue;
+                }
+
+                // Unrecognized character: skip it rather than fail the whole page's parse.
+                i++;
+            }
+
+            EmitNewLineIfNeeded();
+            tokens.Add(new VbsToken { Kind = VbsTokenKind.EndOfFile, Value = string.Empty, Line = line });
+            return tokens;
+        }
+
+        private static bool LooksLikeLineContinuation(string code, int i)
+        {
+            int j = i + 1;
+            while (j < code.Length && (code[j] == ' ' || code[j] == '\t')) j++;
+            return j < code.Length && (code[j] == '\r' || code[j] == '\n');
+        }
+
+        private static bool StartsWithWord(string code, int i, string word)
+        {
+            if (i + word.Length > code.Length) return false;
+            if (!string.Equals(code.Substring(i, word.Length), word, StringComparison.OrdinalIgnoreCase)) return false;
+            int after = i + word.Length;
+            return after >= code.Length || !char.IsLetterOrDigit(code[after]);
+        }
+
+        private static string ReadString(string code, ref int i)
+        {
+            var sb = new StringBuilder();
+            i++; // opening quote
+            while (i < code.Length)
+            {
+                if (code[i] == '"')
+                {
+                    if (i + 1 < code.Length && code[i + 1] == '"') { sb.Append('"'); i += 2; continue; }
+                    i++;
+                    break;
+                }
+                sb.Append(code[i]);
+                i++;
+            }
+            return sb.ToString();
+        }
+
+        private static string ReadNumber(string code, ref int i)
+        {
+            int start = i;
+            bool hasDecimal = false;
+            while (i < code.Length && (char.IsDigit(code[i]) || (code[i] == '.' && !hasDecimal)))
+            {
+                if (code[i] == '.') hasDecimal = true;
+                i++;
+            }
+            return code.Substring(start, i - start);
+        }
+
+        private static string ReadIdentifier(string code, ref int i)
+        {
+            int start = i;
+            while (i < code.Length && (char.IsLetterOrDigit(code[i]) || code[i] == '_')) i++;
+            return code.Substring(start, i - start);
+        }
+
+        private static readonly string[] MultiCharOperators = { "<=", ">=", "<>" };
+
+        private static string? ReadOperator(string code, ref int i)
+        {
+            foreach (var op in MultiCharOperators)
+            {
+                if (i + op.Length <= code.Length && code.Substring(i, op.Length) == op)
+                {
+                    i += op.Length;
+                    return op;
+                }
+            }
+
+            const string singleChar = "+-*/\\^&=<>(),.:";
+            if (singleChar.IndexOf(code[i]) >= 0)
+            {
+                var s = code[i].ToString();
+                i++;
+                return s;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Phase5-ASPtoAngular/AspProjectConverter.cs
+++ b/src/Phase5-ASPtoAngular/AspProjectConverter.cs
@@ -1,0 +1,186 @@
+using System.Text.RegularExpressions;
+using BLML.Phase1Foundation.AST;
+using BLML.Phase4DataAccess.Models;
+using BLML.Phase5ASPtoAngular.Analysis;
+using BLML.Phase5ASPtoAngular.AspParser;
+using BLML.Phase5ASPtoAngular.Backend.ApiGenerator;
+using BLML.Phase5ASPtoAngular.Backend.Infrastructure;
+using BLML.Phase5ASPtoAngular.Database;
+using BLML.Phase5ASPtoAngular.Frontend;
+
+namespace BLML.Phase5ASPtoAngular
+{
+    /// <summary>
+    /// Top-level orchestrator that runs every Phase 5 piece end-to-end over a folder
+    /// of classic ASP pages: parse -> analyze -> generate .NET 8 Web API (Api/) +
+    /// standalone Angular app (ClientApp/) + SQL Server migration scripts (Database/).
+    /// This is the Phase 5 equivalent of what CommandLineInterface's "convert-project"
+    /// does for Phases 1-4 - the thing that makes the individual generators a working
+    /// pipeline instead of a set of independently-testable but disconnected classes.
+    ///
+    /// Scoped to the common case: one representative database query per page (the
+    /// typical classic-ASP list/detail page shape). A page with multiple distinct
+    /// queries only gets its first one converted; everything else it does is still
+    /// parsed, analyzed, and rendered into the template, just not wired to a generated
+    /// API method.
+    /// </summary>
+    public class AspProjectConverter
+    {
+        public class ConversionResult
+        {
+            public List<string> GeneratedFiles { get; } = new();
+            public List<string> Warnings { get; } = new();
+        }
+
+        private readonly AspParser.AspParser _aspParser = new();
+        private readonly DatabaseCallAnalyzer _dbAnalyzer = new();
+        private readonly SessionVariableTracker _sessionTracker = new();
+        private readonly PageFlowAnalyzer _pageFlowAnalyzer = new();
+        private readonly DtoGenerator _dtoGenerator = new();
+        private readonly ServiceGenerator _serviceGenerator = new();
+        private readonly ControllerGenerator _controllerGenerator = new();
+        private readonly AuthConverter _authConverter = new();
+        private readonly MiddlewareGenerator _middlewareGenerator = new();
+        private readonly EFCoreGenerator _efCoreGenerator = new();
+        private readonly MigrationScripts _migrationScripts = new();
+        private readonly TemplateConverter _templateConverter = new();
+        private readonly ComponentGenerator _componentGenerator = new();
+        private readonly RoutingGenerator _routingGenerator = new();
+
+        public ConversionResult ConvertDirectory(string inputDir, string outputDir)
+        {
+            var result = new ConversionResult();
+            var apiDir = Path.Combine(outputDir, "Api");
+            var clientDir = Path.Combine(outputDir, "ClientApp", "src", "app");
+            var dbDir = Path.Combine(outputDir, "Database");
+
+            var aspFiles = Directory.GetFiles(inputDir, "*.asp", SearchOption.TopDirectoryOnly).OrderBy(f => f).ToList();
+            var serviceClassNames = new List<string>();
+            var allFlowEdges = new List<PageFlowEdge>();
+            var allSessionKeys = new Dictionary<string, SessionVariableInfo>(StringComparer.OrdinalIgnoreCase);
+            var tables = new List<TableMetadata>();
+
+            foreach (var filePath in aspFiles)
+            {
+                var pageName = Path.GetFileName(filePath);
+                var resourceName = ToResourceName(pageName);
+                var content = File.ReadAllText(filePath);
+                var page = _aspParser.Parse(content, filePath, inputDir);
+                result.Warnings.AddRange(page.ParseWarnings.Select(w => $"{pageName}: {w}"));
+
+                allFlowEdges.AddRange(_pageFlowAnalyzer.Analyze(page.Statements, pageName));
+                foreach (var kv in _sessionTracker.Catalog(page.Statements))
+                {
+                    if (!allSessionKeys.ContainsKey(kv.Key)) allSessionKeys[kv.Key] = kv.Value;
+                }
+
+                var recordsetSignalNames = new List<string>();
+                var adoObjects = _dbAnalyzer.Analyze(page.Statements);
+                var primaryQuery = adoObjects.SelectMany(o => o.CallSites.Select(s => (obj: o, site: s))).FirstOrDefault();
+
+                if (primaryQuery.site != null)
+                {
+                    var fields = _dbAnalyzer.FindFieldReferences(page.Statements, primaryQuery.obj.VariableName);
+                    var dtoName = resourceName + "Dto";
+                    var table = _efCoreGenerator.BuildTableMetadata(
+                        primaryQuery.site.TablesReferenced.FirstOrDefault() ?? resourceName, fields);
+                    tables.Add(table);
+
+                    WriteFile(result, apiDir, "Dtos", $"{dtoName}.cs", _dtoGenerator.GenerateDto(dtoName, fields));
+
+                    var (verb, isMutation) = ControllerGenerator.DeriveVerbFromSql(primaryQuery.site.SqlText);
+                    var serviceMethodName = (isMutation ? verb[..1] + verb[1..].ToLowerInvariant() : "Get") + resourceName;
+                    var serviceClassName = resourceName + "Service";
+                    serviceClassNames.Add(serviceClassName);
+
+                    var methodSpec = new ServiceMethodSpec { MethodName = serviceMethodName, Site = primaryQuery.site, ResultFields = fields, IsMutation = isMutation };
+                    WriteFile(result, apiDir, "Services", $"{serviceClassName}.cs",
+                        _serviceGenerator.GenerateServiceClass(serviceClassName, dtoName, new[] { methodSpec }));
+
+                    var action = new ControllerActionSpec { MethodName = serviceMethodName, ServiceMethodName = serviceMethodName, HttpVerb = verb };
+                    var controllerClassName = resourceName + "Controller";
+                    WriteFile(result, apiDir, "Controllers", $"{controllerClassName}.cs",
+                        _controllerGenerator.GenerateController(resourceName.ToLowerInvariant(), controllerClassName, serviceClassName, dtoName, new[] { action }));
+
+                    // matches TemplateConverter's own "{camelRs}Items" naming convention for the recordset signal it references
+                    recordsetSignalNames.Add(AspExpressionToTypeScript.ToCamelCase(primaryQuery.obj.VariableName) + "Items");
+                }
+
+                var templateHtml = _templateConverter.Convert(page.Statements);
+                result.Warnings.AddRange(_templateConverter.Warnings.Select(w => $"{pageName}: {w}"));
+
+                var componentClassName = resourceName + "Component";
+                var kebabName = ComponentGenerator.ToKebabCase(resourceName);
+                var dtoInterfaceName = resourceName + "Dto";
+                var generatedComponent = _componentGenerator.GenerateComponent(
+                    componentClassName, $"app-{kebabName}", $"/api/{resourceName.ToLowerInvariant()}", dtoInterfaceName, templateHtml, recordsetSignalNames);
+
+                if (generatedComponent.Findings.Count > 0)
+                {
+                    result.Warnings.AddRange(generatedComponent.Findings.Select(f => $"{pageName}: [{f.Rule}] {f.Message}"));
+                }
+
+                WriteFile(result, clientDir, kebabName, $"{kebabName}.component.ts", generatedComponent.TypeScript);
+                WriteFile(result, clientDir, kebabName, $"{kebabName}.component.html", generatedComponent.Html);
+                WriteFile(result, clientDir, kebabName, $"{kebabName}.component.spec.ts", generatedComponent.Spec);
+                if (primaryQuery.site != null)
+                {
+                    var fields = _dbAnalyzer.FindFieldReferences(page.Statements, primaryQuery.obj.VariableName);
+                    WriteFile(result, clientDir, kebabName, $"{ComponentGenerator.ToKebabCase(dtoInterfaceName)}.model.ts",
+                        _componentGenerator.GenerateDtoInterface(dtoInterfaceName, fields));
+                }
+            }
+
+            if (aspFiles.Count > 0)
+            {
+                var homePage = Path.GetFileName(aspFiles.FirstOrDefault(f => Path.GetFileNameWithoutExtension(f).Equals("index", StringComparison.OrdinalIgnoreCase)) ?? aspFiles[0]);
+                WriteFile(result, clientDir, "", "app.routes.ts", _routingGenerator.GenerateRoutes(allFlowEdges, homePage));
+            }
+
+            if (tables.Count > 0)
+            {
+                WriteFile(result, dbDir, "", "schema.sql", _migrationScripts.GenerateCreateScripts(tables));
+                WriteFile(result, dbDir, "", "bulk-copy.cs", _migrationScripts.GenerateBulkCopyScripts(tables));
+                WriteFile(result, apiDir, "Models", "Entities.cs", _efCoreGenerator.GenerateEntities(tables));
+                WriteFile(result, apiDir, "Data", "ApiDbContext.cs", _efCoreGenerator.GenerateDbContext("ApiDbContext", tables));
+            }
+
+            var identityKeys = allSessionKeys.Keys.Where(k => k.Contains("user", StringComparison.OrdinalIgnoreCase) || k.Contains("role", StringComparison.OrdinalIgnoreCase)).ToList();
+            if (identityKeys.Count > 0)
+            {
+                WriteFile(result, apiDir, "Services", "AuthService.cs", _authConverter.GenerateAuthService(identityKeys));
+            }
+
+            if (serviceClassNames.Count > 0)
+            {
+                WriteFile(result, apiDir, "", "Program.cs", _middlewareGenerator.GenerateProgramCs(serviceClassNames, "http://localhost:4200"));
+            }
+
+            var globalAsaPath = Path.Combine(inputDir, "Global.asa");
+            if (File.Exists(globalAsaPath))
+            {
+                var globalAsa = new GlobalAsaParser().Parse(File.ReadAllText(globalAsaPath));
+                result.Warnings.AddRange(globalAsa.Warnings.Select(w => $"Global.asa: {w}"));
+            }
+
+            return result;
+        }
+
+        private static void WriteFile(ConversionResult result, string baseDir, string subDir, string fileName, string content)
+        {
+            var dir = string.IsNullOrEmpty(subDir) ? baseDir : Path.Combine(baseDir, subDir);
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, fileName);
+            File.WriteAllText(path, content);
+            result.GeneratedFiles.Add(path);
+        }
+
+        private static string ToResourceName(string aspFileName)
+        {
+            var name = aspFileName.EndsWith(".asp", StringComparison.OrdinalIgnoreCase) ? aspFileName[..^4] : aspFileName;
+            var cleaned = Regex.Replace(name, "[^A-Za-z0-9]", " ");
+            var parts = cleaned.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            return parts.Length == 0 ? "Page" : string.Concat(parts.Select(p => char.ToUpperInvariant(p[0]) + p[1..]));
+        }
+    }
+}

--- a/src/Phase5-ASPtoAngular/Backend/ApiGenerator/ControllerGenerator.cs
+++ b/src/Phase5-ASPtoAngular/Backend/ApiGenerator/ControllerGenerator.cs
@@ -1,10 +1,117 @@
+using System.Text;
+using BLML.Phase5ASPtoAngular.Analysis;
+
 namespace BLML.Phase5ASPtoAngular.Backend.ApiGenerator
 {
+    public class ControllerActionSpec
+    {
+        public string MethodName { get; set; } = string.Empty; // e.g. "GetProducts" / "CreateProduct"
+        public string ServiceMethodName { get; set; } = string.Empty; // matches ServiceMethodSpec.MethodName
+        public string HttpVerb { get; set; } = "GET"; // GET, POST, PUT, DELETE
+        public bool HasIdRouteParameter { get; set; }
+    }
+
+    /// <summary>
+    /// Generates a standard ASP.NET Core `[ApiController]` following the REST
+    /// conventions ProjectPlan.md's "API Design Patterns" section calls for: plural
+    /// resource routes, one verb per CRUD operation, `Ok`/`NotFound`/`NoContent`
+    /// mapped to the right status code rather than always returning 200.
+    /// </summary>
     public class ControllerGenerator
     {
-        public string GenerateController(string name)
+        public string GenerateController(string resourceName, string controllerClassName, string serviceName, string dtoName,
+            IEnumerable<ControllerActionSpec> actions, string @namespace = "BLML.Api.Controllers")
         {
-            return $"public class {name}Controller : ControllerBase {{ }}";
+            var sb = new StringBuilder();
+            sb.AppendLine("using Microsoft.AspNetCore.Mvc;");
+            sb.AppendLine("using System.Threading.Tasks;");
+            sb.AppendLine("using BLML.Api.Dtos;");
+            sb.AppendLine("using BLML.Api.Services;");
+            sb.AppendLine();
+            sb.AppendLine($"namespace {@namespace}");
+            sb.AppendLine("{");
+            sb.AppendLine("    [ApiController]");
+            sb.AppendLine($"    [Route(\"api/{resourceName.ToLowerInvariant()}\")]");
+            sb.AppendLine($"    public class {controllerClassName} : ControllerBase");
+            sb.AppendLine("    {");
+            sb.AppendLine($"        private readonly {serviceName} _service;");
+            sb.AppendLine();
+            sb.AppendLine($"        public {controllerClassName}({serviceName} service)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            _service = service;");
+            sb.AppendLine("        }");
+
+            foreach (var action in actions)
+            {
+                sb.AppendLine();
+                AppendAction(sb, action, dtoName);
+            }
+
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        private void AppendAction(StringBuilder sb, ControllerActionSpec action, string dtoName)
+        {
+            switch (action.HttpVerb.ToUpperInvariant())
+            {
+                case "GET":
+                    var route = action.HasIdRouteParameter ? "\"{id}\"" : "";
+                    var param = action.HasIdRouteParameter ? "int id" : "";
+                    var arg = action.HasIdRouteParameter ? "id" : "";
+                    sb.AppendLine($"        [HttpGet({route})]");
+                    sb.AppendLine($"        public async Task<IActionResult> {action.MethodName}({param})");
+                    sb.AppendLine("        {");
+                    sb.AppendLine($"            var result = await _service.{action.ServiceMethodName}Async({arg});");
+                    sb.AppendLine(action.HasIdRouteParameter
+                        ? "            return result.Count > 0 ? Ok(result[0]) : NotFound();"
+                        : "            return Ok(result);");
+                    sb.AppendLine("        }");
+                    break;
+
+                case "POST":
+                    sb.AppendLine("        [HttpPost]");
+                    sb.AppendLine($"        public async Task<IActionResult> {action.MethodName}([FromBody] {dtoName} body)");
+                    sb.AppendLine("        {");
+                    sb.AppendLine($"            var affected = await _service.{action.ServiceMethodName}Async(body);");
+                    sb.AppendLine("            return affected > 0 ? StatusCode(201) : BadRequest();");
+                    sb.AppendLine("        }");
+                    break;
+
+                case "PUT":
+                    sb.AppendLine("        [HttpPut(\"{id}\")]");
+                    sb.AppendLine($"        public async Task<IActionResult> {action.MethodName}(int id, [FromBody] {dtoName} body)");
+                    sb.AppendLine("        {");
+                    sb.AppendLine($"            var affected = await _service.{action.ServiceMethodName}Async(id, body);");
+                    sb.AppendLine("            return affected > 0 ? NoContent() : NotFound();");
+                    sb.AppendLine("        }");
+                    break;
+
+                case "DELETE":
+                    sb.AppendLine("        [HttpDelete(\"{id}\")]");
+                    sb.AppendLine($"        public async Task<IActionResult> {action.MethodName}(int id)");
+                    sb.AppendLine("        {");
+                    sb.AppendLine($"            var affected = await _service.{action.ServiceMethodName}Async(id);");
+                    sb.AppendLine("            return affected > 0 ? NoContent() : NotFound();");
+                    sb.AppendLine("        }");
+                    break;
+            }
+        }
+
+        /// <summary>Maps a reconstructed SQL statement's leading verb to the REST verb ProjectPlan.md's API conventions call for.</summary>
+        public static (string httpVerb, bool isMutation) DeriveVerbFromSql(string sqlText)
+        {
+            var trimmed = sqlText.TrimStart();
+            var firstWord = trimmed.Split(' ', '\t', '\n').FirstOrDefault() ?? "";
+            return firstWord.ToUpperInvariant() switch
+            {
+                "SELECT" => ("GET", false),
+                "INSERT" => ("POST", true),
+                "UPDATE" => ("PUT", true),
+                "DELETE" => ("DELETE", true),
+                _ => ("GET", false)
+            };
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/Backend/ApiGenerator/DtoGenerator.cs
+++ b/src/Phase5-ASPtoAngular/Backend/ApiGenerator/DtoGenerator.cs
@@ -1,10 +1,38 @@
+using System.Text;
+
 namespace BLML.Phase5ASPtoAngular.Backend.ApiGenerator
 {
+    /// <summary>
+    /// Classic ASP has no schema to read a shape from - a page just does
+    /// `rs("FieldName")` and trusts whatever the query returned. DtoGenerator turns
+    /// the field names DatabaseCallAnalyzer.FindFieldReferences found into a C# record,
+    /// typed `object?` with an explicit TODO rather than guessing a type, so nothing
+    /// downstream silently assumes a wrong type.
+    /// </summary>
     public class DtoGenerator
     {
-        public string GenerateDto(string name)
+        public string GenerateDto(string dtoName, IReadOnlyList<string> fieldNames, string @namespace = "BLML.Api.Dtos")
         {
-            return $"public class {name}Dto {{ }}";
+            var sb = new StringBuilder();
+            sb.AppendLine($"namespace {@namespace}");
+            sb.AppendLine("{");
+            sb.AppendLine($"    public class {dtoName}");
+            sb.AppendLine("    {");
+            foreach (var field in fieldNames)
+            {
+                var propertyName = ToPascalCase(field);
+                sb.AppendLine($"        // TODO: verify type - inferred from ASP `rs(\"{field}\")` usage, no schema was available.");
+                sb.AppendLine($"        public object? {propertyName} {{ get; set; }}");
+            }
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        private static string ToPascalCase(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return name;
+            return char.ToUpperInvariant(name[0]) + name[1..];
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/Backend/ApiGenerator/ServiceGenerator.cs
+++ b/src/Phase5-ASPtoAngular/Backend/ApiGenerator/ServiceGenerator.cs
@@ -1,10 +1,139 @@
+using System.Text;
+using BLML.Phase5ASPtoAngular.Analysis;
+
 namespace BLML.Phase5ASPtoAngular.Backend.ApiGenerator
 {
+    public class ServiceMethodSpec
+    {
+        public string MethodName { get; set; } = string.Empty;
+        public DatabaseCallSite Site { get; set; } = null!;
+        public IReadOnlyList<string> ResultFields { get; set; } = Array.Empty<string>();
+        /// <summary>True for INSERT/UPDATE/DELETE (returns affected-row count); false for SELECT (returns a list).</summary>
+        public bool IsMutation { get; set; }
+    }
+
+    /// <summary>
+    /// Turns a <see cref="DatabaseCallSite"/> into an ADO.NET service method that is
+    /// ALWAYS parameterized - regardless of whether the original ASP code built its
+    /// SQL by safe literal concatenation or by splicing raw request/session state into
+    /// the string (<see cref="DatabaseCallSite.BuiltByUnsafeConcatenation"/>). The
+    /// point of running the original page through DatabaseCallAnalyzer at all is that
+    /// downstream generation never has to make that judgment call per-site: every `?`
+    /// placeholder becomes a bound SqlParameter, full stop.
+    /// </summary>
     public class ServiceGenerator
     {
-        public string GenerateService(string name)
+        public string GenerateServiceClass(string serviceName, string dtoName, IEnumerable<ServiceMethodSpec> methods, string @namespace = "BLML.Api.Services")
         {
-            return $"public class {name}Service {{ }}";
+            var sb = new StringBuilder();
+            sb.AppendLine("using Microsoft.Data.SqlClient;");
+            sb.AppendLine("using System.Threading.Tasks;");
+            sb.AppendLine("using System.Collections.Generic;");
+            sb.AppendLine($"using BLML.Api.Dtos;");
+            sb.AppendLine();
+            sb.AppendLine($"namespace {@namespace}");
+            sb.AppendLine("{");
+            sb.AppendLine($"    public class {serviceName}");
+            sb.AppendLine("    {");
+            sb.AppendLine("        private readonly string _connectionString;");
+            sb.AppendLine();
+            sb.AppendLine($"        public {serviceName}(string connectionString)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            _connectionString = connectionString;");
+            sb.AppendLine("        }");
+
+            foreach (var method in methods)
+            {
+                sb.AppendLine();
+                AppendMethod(sb, method, dtoName);
+            }
+
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            return sb.ToString();
         }
+
+        private void AppendMethod(StringBuilder sb, ServiceMethodSpec method, string dtoName)
+        {
+            var (parameterizedSql, paramNames) = Parameterize(method.Site);
+            var parameterList = string.Join(", ", paramNames.Select(p => $"object {p}"));
+
+            if (method.IsMutation)
+            {
+                sb.AppendLine($"        public async Task<int> {method.MethodName}Async({parameterList})");
+                sb.AppendLine("        {");
+                sb.AppendLine("            using var connection = new SqlConnection(_connectionString);");
+                sb.AppendLine("            await connection.OpenAsync();");
+                sb.AppendLine($"            using var command = new SqlCommand(\"{Escape(parameterizedSql)}\", connection);");
+                foreach (var p in paramNames)
+                {
+                    sb.AppendLine($"            command.Parameters.AddWithValue(\"@{p}\", {p});");
+                }
+                sb.AppendLine("            return await command.ExecuteNonQueryAsync();");
+                sb.AppendLine("        }");
+                return;
+            }
+
+            sb.AppendLine($"        public async Task<List<{dtoName}>> {method.MethodName}Async({parameterList})");
+            sb.AppendLine("        {");
+            sb.AppendLine($"            var results = new List<{dtoName}>();");
+            sb.AppendLine("            using var connection = new SqlConnection(_connectionString);");
+            sb.AppendLine("            await connection.OpenAsync();");
+            sb.AppendLine($"            using var command = new SqlCommand(\"{Escape(parameterizedSql)}\", connection);");
+            foreach (var p in paramNames)
+            {
+                sb.AppendLine($"            command.Parameters.AddWithValue(\"@{p}\", {p});");
+            }
+            sb.AppendLine("            using var reader = await command.ExecuteReaderAsync();");
+            sb.AppendLine("            while (await reader.ReadAsync())");
+            sb.AppendLine("            {");
+            sb.AppendLine($"                results.Add(new {dtoName}");
+            sb.AppendLine("                {");
+            foreach (var field in method.ResultFields)
+            {
+                var prop = char.ToUpperInvariant(field[0]) + field[1..];
+                sb.AppendLine($"                    {prop} = reader[\"{field}\"],");
+            }
+            sb.AppendLine("                });");
+            sb.AppendLine("            }");
+            sb.AppendLine("            return results;");
+            sb.AppendLine("        }");
+        }
+
+        /// <summary>Replaces each `?` in the reconstructed SQL with a distinct `@pN` and returns the matching bind-parameter names.</summary>
+        private static (string sql, List<string> paramNames) Parameterize(DatabaseCallSite site)
+        {
+            var paramNames = new List<string>();
+            var sb = new StringBuilder();
+            int placeholderIndex = 0;
+
+            foreach (var ch in site.SqlText)
+            {
+                if (ch == '?')
+                {
+                    var name = SanitizeParamName(
+                        placeholderIndex < site.ConcatenatedParameterExpressions.Count
+                            ? site.ConcatenatedParameterExpressions[placeholderIndex]
+                            : $"p{placeholderIndex}");
+                    paramNames.Add(name);
+                    sb.Append('@').Append(name);
+                    placeholderIndex++;
+                }
+                else
+                {
+                    sb.Append(ch);
+                }
+            }
+
+            return (sb.ToString(), paramNames);
+        }
+
+        private static string SanitizeParamName(string raw)
+        {
+            var cleaned = new string(raw.Where(char.IsLetterOrDigit).ToArray());
+            return string.IsNullOrEmpty(cleaned) ? "value" : char.IsDigit(cleaned[0]) ? "p" + cleaned : cleaned;
+        }
+
+        private static string Escape(string sql) => sql.Replace("\\", "\\\\").Replace("\"", "\\\"");
     }
 }

--- a/src/Phase5-ASPtoAngular/Backend/Infrastructure/AuthConverter.cs
+++ b/src/Phase5-ASPtoAngular/Backend/Infrastructure/AuthConverter.cs
@@ -1,10 +1,73 @@
+using System.Text;
+using BLML.Phase5ASPtoAngular.Analysis;
+
 namespace BLML.Phase5ASPtoAngular.Backend.Infrastructure
 {
+    /// <summary>
+    /// Classic ASP session-based auth has no single equivalent in a stateless Web API -
+    /// this converts it to JWT bearer auth, and specifically normalizes the three
+    /// interchangeable "is this session value unset" idioms SessionVariableTracker
+    /// found (`= ""`, `IsEmpty(...)`, `Is Nothing`) into one consistent claims check,
+    /// since a straight per-idiom translation would leave the generated code just as
+    /// inconsistent as the ASP it came from.
+    /// </summary>
     public class AuthConverter
     {
-        public void ConvertAuth()
+        public string GenerateAuthService(IEnumerable<string> identityClaimKeys, string @namespace = "BLML.Api.Services")
         {
-            // Convert ASP Classic auth to JWT/Identity
+            var sb = new StringBuilder();
+            sb.AppendLine("using System.IdentityModel.Tokens.Jwt;");
+            sb.AppendLine("using System.Security.Claims;");
+            sb.AppendLine("using System.Text;");
+            sb.AppendLine("using Microsoft.IdentityModel.Tokens;");
+            sb.AppendLine();
+            sb.AppendLine($"namespace {@namespace}");
+            sb.AppendLine("{");
+            sb.AppendLine("    public class AuthService");
+            sb.AppendLine("    {");
+            sb.AppendLine("        private readonly string _signingKey;");
+            sb.AppendLine();
+            sb.AppendLine("        public AuthService(string signingKey)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            _signingKey = signingKey;");
+            sb.AppendLine("        }");
+            sb.AppendLine();
+            sb.AppendLine("        // Session(\"key\") values that identified the user in the original ASP pages become");
+            sb.AppendLine("        // JWT claims here, issued once at login instead of being re-read from server-side session state on every request.");
+            sb.AppendLine("        public string IssueToken(Dictionary<string, string> identityValues)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            var claims = new List<Claim>();");
+            foreach (var key in identityClaimKeys)
+            {
+                sb.AppendLine($"            if (identityValues.TryGetValue(\"{key}\", out var {ToCamelCase(key)}Value)) claims.Add(new Claim(\"{key}\", {ToCamelCase(key)}Value));");
+            }
+            sb.AppendLine("            var keyBytes = Encoding.UTF8.GetBytes(_signingKey);");
+            sb.AppendLine("            var credentials = new SigningCredentials(new SymmetricSecurityKey(keyBytes), SecurityAlgorithms.HmacSha256);");
+            sb.AppendLine("            var token = new JwtSecurityToken(claims: claims, expires: DateTime.UtcNow.AddHours(8), signingCredentials: credentials);");
+            sb.AppendLine("            return new JwtSecurityTokenHandler().WriteToken(token);");
+            sb.AppendLine("        }");
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            return sb.ToString();
         }
+
+        /// <summary>
+        /// Emits one normalized claims-null-check regardless of which idiom(s) the
+        /// original ASP page mixed for this session key - `User.HasClaim` is the single
+        /// C# equivalent of "is this identity value set" that all three VBScript forms
+        /// collapse to.
+        /// </summary>
+        public string GenerateNormalizedNullCheck(SessionVariableInfo info)
+        {
+            if (info.NullCheckIdiomsObserved.Count > 1)
+            {
+                return $"// NOTE: original ASP pages checked \"{info.Name}\" for emptiness using {info.NullCheckIdiomsObserved.Count} different idioms ({string.Join(", ", info.NullCheckIdiomsObserved)}); normalized to one check below.\n"
+                     + $"!User.HasClaim(c => c.Type == \"{info.Name}\")";
+            }
+            return $"!User.HasClaim(c => c.Type == \"{info.Name}\")";
+        }
+
+        private static string ToCamelCase(string name) =>
+            string.IsNullOrEmpty(name) ? name : char.ToLowerInvariant(name[0]) + name[1..];
     }
 }

--- a/src/Phase5-ASPtoAngular/Backend/Infrastructure/MiddlewareGenerator.cs
+++ b/src/Phase5-ASPtoAngular/Backend/Infrastructure/MiddlewareGenerator.cs
@@ -1,10 +1,84 @@
+using System.Text;
+
 namespace BLML.Phase5ASPtoAngular.Backend.Infrastructure
 {
+    /// <summary>
+    /// Generates the top-level-statement `Program.cs` for the migrated Web API:
+    /// DI registration for every generated service, JWT bearer auth (matching
+    /// AuthConverter's issued tokens), CORS scoped to the Angular dev/prod origin
+    /// (ProjectPlan.md item 63), global exception handling instead of letting an
+    /// unhandled ADO exception leak a stack trace to the client, and Swagger/OpenAPI
+    /// (item 121) wired up from the start rather than bolted on later.
+    /// </summary>
     public class MiddlewareGenerator
     {
-        public void GenerateMiddleware()
+        public string GenerateProgramCs(IEnumerable<string> serviceClassNames, string angularOrigin, string connectionStringConfigKey = "DefaultConnection")
         {
-            // Generate ASP.NET Core middleware
+            var sb = new StringBuilder();
+            sb.AppendLine("using Microsoft.AspNetCore.Authentication.JwtBearer;");
+            sb.AppendLine("using Microsoft.IdentityModel.Tokens;");
+            sb.AppendLine("using System.Text;");
+            sb.AppendLine("using BLML.Api.Services;");
+            sb.AppendLine();
+            sb.AppendLine("var builder = WebApplication.CreateBuilder(args);");
+            sb.AppendLine();
+            sb.AppendLine("builder.Services.AddControllers();");
+            sb.AppendLine("builder.Services.AddEndpointsApiExplorer();");
+            sb.AppendLine("builder.Services.AddSwaggerGen();");
+            sb.AppendLine();
+            sb.AppendLine($"var connectionString = builder.Configuration.GetConnectionString(\"{connectionStringConfigKey}\") ?? string.Empty;");
+            foreach (var service in serviceClassNames)
+            {
+                sb.AppendLine($"builder.Services.AddScoped<{service}>(_ => new {service}(connectionString));");
+            }
+            sb.AppendLine("builder.Services.AddScoped<AuthService>(_ => new AuthService(builder.Configuration[\"Jwt:SigningKey\"] ?? string.Empty));");
+            sb.AppendLine();
+            sb.AppendLine("builder.Services.AddCors(options =>");
+            sb.AppendLine("{");
+            sb.AppendLine("    options.AddDefaultPolicy(policy =>");
+            sb.AppendLine($"        policy.WithOrigins(\"{angularOrigin}\").AllowAnyHeader().AllowAnyMethod());");
+            sb.AppendLine("});");
+            sb.AppendLine();
+            sb.AppendLine("builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)");
+            sb.AppendLine("    .AddJwtBearer(options =>");
+            sb.AppendLine("    {");
+            sb.AppendLine("        var signingKey = builder.Configuration[\"Jwt:SigningKey\"] ?? string.Empty;");
+            sb.AppendLine("        options.TokenValidationParameters = new TokenValidationParameters");
+            sb.AppendLine("        {");
+            sb.AppendLine("            ValidateIssuer = false,");
+            sb.AppendLine("            ValidateAudience = false,");
+            sb.AppendLine("            ValidateLifetime = true,");
+            sb.AppendLine("            ValidateIssuerSigningKey = true,");
+            sb.AppendLine("            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(signingKey))");
+            sb.AppendLine("        };");
+            sb.AppendLine("    });");
+            sb.AppendLine("builder.Services.AddAuthorization();");
+            sb.AppendLine();
+            sb.AppendLine("var app = builder.Build();");
+            sb.AppendLine();
+            sb.AppendLine("app.UseExceptionHandler(errorApp =>");
+            sb.AppendLine("{");
+            sb.AppendLine("    errorApp.Run(async context =>");
+            sb.AppendLine("    {");
+            sb.AppendLine("        context.Response.StatusCode = 500;");
+            sb.AppendLine("        context.Response.ContentType = \"application/json\";");
+            sb.AppendLine("        await context.Response.WriteAsJsonAsync(new { error = \"An unexpected error occurred.\" });");
+            sb.AppendLine("    });");
+            sb.AppendLine("});");
+            sb.AppendLine();
+            sb.AppendLine("if (app.Environment.IsDevelopment())");
+            sb.AppendLine("{");
+            sb.AppendLine("    app.UseSwagger();");
+            sb.AppendLine("    app.UseSwaggerUI();");
+            sb.AppendLine("}");
+            sb.AppendLine();
+            sb.AppendLine("app.UseHttpsRedirection();");
+            sb.AppendLine("app.UseCors();");
+            sb.AppendLine("app.UseAuthentication();");
+            sb.AppendLine("app.UseAuthorization();");
+            sb.AppendLine("app.MapControllers();");
+            sb.AppendLine("app.Run();");
+            return sb.ToString();
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/Database/EFCoreGenerator.cs
+++ b/src/Phase5-ASPtoAngular/Database/EFCoreGenerator.cs
@@ -1,9 +1,41 @@
+using System.Text;
+using BLML.Phase4DataAccess.EntityFramework;
+using BLML.Phase4DataAccess.Models;
+
 namespace BLML.Phase5ASPtoAngular.Database
 {
+    /// <summary>
+    /// Bridges Phase 5's ASP-derived table/field data (DatabaseCallAnalyzer's
+    /// discovered tables and rs("Field") references - the only schema information
+    /// available, since classic ASP/Access has none to read directly) into Phase 4's
+    /// already-implemented EF Core generators (EntityGenerator, DbContextGenerator)
+    /// rather than reimplementing entity/DbContext generation a second time.
+    /// </summary>
     public class EFCoreGenerator
     {
-        public void Generate()
+        private readonly EntityGenerator _entityGenerator = new();
+        private readonly DbContextGenerator _dbContextGenerator = new();
+
+        /// <summary>Field types are unknown (ASP has no schema) - every column defaults to nullable string, same "no schema" stance DtoGenerator takes on the API side.</summary>
+        public TableMetadata BuildTableMetadata(string tableName, IReadOnlyList<string> fieldNames, IReadOnlyList<string>? primaryKeyColumns = null)
         {
+            var table = new TableMetadata { Name = tableName };
+            table.Columns.AddRange(fieldNames.Select(f => new ColumnMetadata { Name = f, DataType = "string", IsNullable = true }));
+            if (primaryKeyColumns != null) table.PrimaryKeyColumns.AddRange(primaryKeyColumns);
+            return table;
         }
+
+        public string GenerateEntities(IEnumerable<TableMetadata> tables, string @namespace = "BLML.Api.Models")
+        {
+            var sb = new StringBuilder();
+            foreach (var table in tables)
+            {
+                sb.AppendLine(_entityGenerator.GenerateEntity(table, @namespace));
+            }
+            return sb.ToString();
+        }
+
+        public string GenerateDbContext(string contextClassName, List<TableMetadata> tables, string @namespace = "BLML.Api.Data") =>
+            _dbContextGenerator.GenerateDbContext(contextClassName, tables, @namespace);
     }
 }

--- a/src/Phase5-ASPtoAngular/Database/MigrationScripts.cs
+++ b/src/Phase5-ASPtoAngular/Database/MigrationScripts.cs
@@ -1,10 +1,38 @@
+using System.Text;
+using BLML.Phase4DataAccess.Models;
+using BLML.Phase4DataAccess.SqlServer;
+
 namespace BLML.Phase5ASPtoAngular.Database
 {
+    /// <summary>
+    /// Generates the SQL Server schema and Access-to-SQL-Server data migration scripts
+    /// for tables discovered by DatabaseCallAnalyzer, delegating to Phase 4's
+    /// SchemaGenerator/DataMigration (already implemented and tested) rather than
+    /// duplicating T-SQL generation for a second migration path.
+    /// </summary>
     public class MigrationScripts
     {
-        public string GenerateScripts()
+        private readonly SchemaGenerator _schemaGenerator = new();
+        private readonly DataMigration _dataMigration = new();
+
+        public string GenerateCreateScripts(IEnumerable<TableMetadata> tables)
         {
-            return "-- SQL Migration Scripts";
+            var sb = new StringBuilder();
+            foreach (var table in tables)
+            {
+                sb.AppendLine(_schemaGenerator.GenerateCreateScript(table));
+            }
+            return sb.ToString();
+        }
+
+        public string GenerateBulkCopyScripts(IEnumerable<TableMetadata> tables)
+        {
+            var sb = new StringBuilder();
+            foreach (var table in tables)
+            {
+                sb.AppendLine(_dataMigration.GenerateBulkCopyCode(table.Name));
+            }
+            return sb.ToString();
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/Database/RepositoryGenerator.cs
+++ b/src/Phase5-ASPtoAngular/Database/RepositoryGenerator.cs
@@ -1,10 +1,91 @@
+using System.Text;
+using BLML.Phase4DataAccess.Models;
+
 namespace BLML.Phase5ASPtoAngular.Database
 {
+    /// <summary>
+    /// Generates a repository interface/implementation pair over an EF Core DbContext
+    /// for a discovered table - the one piece of Phase 5's database story Phase 4
+    /// doesn't already provide (Phase 4 stops at entities/DbContext/schema scripts).
+    /// This gives the migrated app a path off ServiceGenerator's direct ADO.NET
+    /// translation (which intentionally preserves the original SQL/behavior exactly)
+    /// toward ordinary EF Core data access, per ProjectPlan.md item 77.
+    /// </summary>
     public class RepositoryGenerator
     {
-        public string GenerateRepository(string entity)
+        public string GenerateRepositoryInterface(TableMetadata table, string @namespace = "BLML.Api.Data")
         {
-            return $"public class {entity}Repository : I{entity}Repository {{ }}";
+            var idType = table.PrimaryKeyColumns.Count == 1 ? "int" : "object";
+            var sb = new StringBuilder();
+            sb.AppendLine("using System.Threading.Tasks;");
+            sb.AppendLine("using System.Collections.Generic;");
+            sb.AppendLine($"using BLML.Api.Models;");
+            sb.AppendLine();
+            sb.AppendLine($"namespace {@namespace}");
+            sb.AppendLine("{");
+            sb.AppendLine($"    public interface I{table.Name}Repository");
+            sb.AppendLine("    {");
+            sb.AppendLine($"        Task<List<{table.Name}>> GetAllAsync();");
+            sb.AppendLine($"        Task<{table.Name}?> GetByIdAsync({idType} id);");
+            sb.AppendLine($"        Task AddAsync({table.Name} entity);");
+            sb.AppendLine($"        Task UpdateAsync({table.Name} entity);");
+            sb.AppendLine($"        Task DeleteAsync({idType} id);");
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        public string GenerateRepositoryImplementation(TableMetadata table, string dbContextClassName, string @namespace = "BLML.Api.Data")
+        {
+            var idColumn = table.PrimaryKeyColumns.FirstOrDefault() ?? "Id";
+            var idType = table.PrimaryKeyColumns.Count == 1 ? "int" : "object";
+            var dbSetName = table.Name + "s";
+
+            var sb = new StringBuilder();
+            sb.AppendLine("using System.Threading.Tasks;");
+            sb.AppendLine("using System.Collections.Generic;");
+            sb.AppendLine("using System.Linq;");
+            sb.AppendLine("using Microsoft.EntityFrameworkCore;");
+            sb.AppendLine($"using BLML.Api.Models;");
+            sb.AppendLine();
+            sb.AppendLine($"namespace {@namespace}");
+            sb.AppendLine("{");
+            sb.AppendLine($"    public class {table.Name}Repository : I{table.Name}Repository");
+            sb.AppendLine("    {");
+            sb.AppendLine($"        private readonly {dbContextClassName} _context;");
+            sb.AppendLine();
+            sb.AppendLine($"        public {table.Name}Repository({dbContextClassName} context)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            _context = context;");
+            sb.AppendLine("        }");
+            sb.AppendLine();
+            sb.AppendLine($"        public async Task<List<{table.Name}>> GetAllAsync() => await _context.{dbSetName}.ToListAsync();");
+            sb.AppendLine();
+            sb.AppendLine($"        public async Task<{table.Name}?> GetByIdAsync({idType} id) =>");
+            sb.AppendLine($"            await _context.{dbSetName}.FirstOrDefaultAsync(e => e.{idColumn}.Equals(id));");
+            sb.AppendLine();
+            sb.AppendLine($"        public async Task AddAsync({table.Name} entity)");
+            sb.AppendLine("        {");
+            sb.AppendLine($"            _context.{dbSetName}.Add(entity);");
+            sb.AppendLine("            await _context.SaveChangesAsync();");
+            sb.AppendLine("        }");
+            sb.AppendLine();
+            sb.AppendLine($"        public async Task UpdateAsync({table.Name} entity)");
+            sb.AppendLine("        {");
+            sb.AppendLine($"            _context.{dbSetName}.Update(entity);");
+            sb.AppendLine("            await _context.SaveChangesAsync();");
+            sb.AppendLine("        }");
+            sb.AppendLine();
+            sb.AppendLine($"        public async Task DeleteAsync({idType} id)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            var entity = await GetByIdAsync(id);");
+            sb.AppendLine("            if (entity is null) return;");
+            sb.AppendLine($"            _context.{dbSetName}.Remove(entity);");
+            sb.AppendLine("            await _context.SaveChangesAsync();");
+            sb.AppendLine("        }");
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            return sb.ToString();
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/Frontend/AngularAntiPatternChecker.cs
+++ b/src/Phase5-ASPtoAngular/Frontend/AngularAntiPatternChecker.cs
@@ -1,0 +1,169 @@
+using System.Text.RegularExpressions;
+
+namespace BLML.Phase5ASPtoAngular.Frontend
+{
+    public enum AntiPatternSeverity { Error, Warning }
+
+    public class AntiPatternFinding
+    {
+        public string Rule { get; set; } = string.Empty;
+        public AntiPatternSeverity Severity { get; set; }
+        public string Message { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Lints generated Angular output against the modern (Angular 17+) conventions
+    /// this generator targets - standalone components, `@if`/`@for`/`@switch` instead
+    /// of `*ngIf`/`*ngFor`/`*ngSwitch`, `inject()` over constructor injection, typed
+    /// Reactive Forms over `[(ngModel)]`, and no untracked `.subscribe()` or `any`.
+    ///
+    /// This runs on EVERY component ComponentGenerator produces (see its unit tests) -
+    /// the point is a build-time guarantee that the generator's own output never
+    /// regresses into the patterns it was written specifically to avoid, not a general
+    /// purpose linter for hand-written Angular code.
+    /// </summary>
+    public class AngularAntiPatternChecker
+    {
+        private static readonly Regex LegacyStructuralDirective = new(@"\*ng(If|For|Switch)\b", RegexOptions.Compiled);
+        private static readonly Regex ForBlockStart = new(@"@for\s*\(", RegexOptions.Compiled);
+        private static readonly Regex NgModelBinding = new(@"\[\(ngModel\)\]", RegexOptions.Compiled);
+        private static readonly Regex AnyType = new(@":\s*any\b", RegexOptions.Compiled);
+        private static readonly Regex Subscribe = new(@"\.subscribe\s*\(", RegexOptions.Compiled);
+        private static readonly Regex TakeUntilDestroyedOrAsyncPipe = new(@"takeUntilDestroyed|async\s*pipe|\|\s*async", RegexOptions.Compiled);
+        private static readonly Regex ComponentDecorator = new(@"@Component\s*\(\s*\{", RegexOptions.Compiled);
+        private static readonly Regex StandaloneTrue = new(@"standalone\s*:\s*true", RegexOptions.Compiled);
+        private static readonly Regex NgModule = new(@"@NgModule\b", RegexOptions.Compiled);
+        private static readonly Regex ConstructorInjection = new(@"constructor\s*\(\s*(private|public|protected|readonly)\b", RegexOptions.Compiled);
+        private static readonly Regex InjectFunction = new(@"\binject\s*\(", RegexOptions.Compiled);
+        private static readonly Regex DirectDomAccess = new(@"\bdocument\.|ElementRef\b", RegexOptions.Compiled);
+
+        public List<AntiPatternFinding> CheckTemplate(string html)
+        {
+            var findings = new List<AntiPatternFinding>();
+
+            foreach (Match m in LegacyStructuralDirective.Matches(html))
+            {
+                findings.Add(new AntiPatternFinding
+                {
+                    Rule = "no-legacy-structural-directives",
+                    Severity = AntiPatternSeverity.Error,
+                    Message = $"Found legacy structural directive '*ng{m.Groups[1].Value}' - use the built-in @if/@for/@switch control flow instead."
+                });
+            }
+
+            foreach (Match m in ForBlockStart.Matches(html))
+            {
+                var header = ExtractBalancedParenContent(html, m.Index + m.Length - 1);
+                if (header != null && !header.Contains("track"))
+                {
+                    findings.Add(new AntiPatternFinding
+                    {
+                        Rule = "for-requires-track",
+                        Severity = AntiPatternSeverity.Error,
+                        Message = $"@for block '@for ({header})' has no track expression - required for correct change detection."
+                    });
+                }
+            }
+
+            if (NgModelBinding.IsMatch(html))
+            {
+                findings.Add(new AntiPatternFinding
+                {
+                    Rule = "no-ngmodel-two-way-binding",
+                    Severity = AntiPatternSeverity.Warning,
+                    Message = "Found [(ngModel)] two-way binding - prefer a typed Reactive Form (FormGroup/FormControl) for form input."
+                });
+            }
+
+            return findings;
+        }
+
+        /// <summary>
+        /// Given the index of an opening '(', returns the text between it and its
+        /// matching ')' (paren depth tracked, so a nested call like `rsItems()` inside
+        /// the @for header doesn't fool a naive "up to the first )" scan). Returns null
+        /// if the parens are unbalanced.
+        /// </summary>
+        private static string? ExtractBalancedParenContent(string text, int openParenIndex)
+        {
+            int depth = 0;
+            for (int i = openParenIndex; i < text.Length; i++)
+            {
+                if (text[i] == '(') depth++;
+                else if (text[i] == ')')
+                {
+                    depth--;
+                    if (depth == 0) return text.Substring(openParenIndex + 1, i - openParenIndex - 1);
+                }
+            }
+            return null;
+        }
+
+        public List<AntiPatternFinding> CheckComponent(string typescript)
+        {
+            var findings = new List<AntiPatternFinding>();
+
+            if (NgModule.IsMatch(typescript))
+            {
+                findings.Add(new AntiPatternFinding
+                {
+                    Rule = "no-ngmodule",
+                    Severity = AntiPatternSeverity.Error,
+                    Message = "Found @NgModule - this generator targets standalone components only, with no module wiring."
+                });
+            }
+
+            if (ComponentDecorator.IsMatch(typescript) && !StandaloneTrue.IsMatch(typescript))
+            {
+                findings.Add(new AntiPatternFinding
+                {
+                    Rule = "component-must-be-standalone",
+                    Severity = AntiPatternSeverity.Error,
+                    Message = "@Component is missing 'standalone: true'."
+                });
+            }
+
+            if (AnyType.IsMatch(typescript))
+            {
+                findings.Add(new AntiPatternFinding
+                {
+                    Rule = "no-any-type",
+                    Severity = AntiPatternSeverity.Warning,
+                    Message = "Found ': any' - use a specific type (the generated DTO, a primitive, or a named interface)."
+                });
+            }
+
+            if (Subscribe.IsMatch(typescript) && !TakeUntilDestroyedOrAsyncPipe.IsMatch(typescript))
+            {
+                findings.Add(new AntiPatternFinding
+                {
+                    Rule = "no-unmanaged-subscribe",
+                    Severity = AntiPatternSeverity.Warning,
+                    Message = "Found .subscribe() with no visible takeUntilDestroyed()/async pipe - this leaks the subscription. Prefer toSignal()/the async pipe, or add takeUntilDestroyed()."
+                });
+            }
+
+            if (ConstructorInjection.IsMatch(typescript) && !InjectFunction.IsMatch(typescript))
+            {
+                findings.Add(new AntiPatternFinding
+                {
+                    Rule = "prefer-inject-function",
+                    Severity = AntiPatternSeverity.Warning,
+                    Message = "Found constructor-parameter dependency injection - prefer the inject() function, this generator's house style."
+                });
+            }
+
+            if (DirectDomAccess.IsMatch(typescript))
+            {
+                findings.Add(new AntiPatternFinding
+                {
+                    Rule = "no-direct-dom-access",
+                    Severity = AntiPatternSeverity.Warning,
+                    Message = "Found direct DOM access (document./ElementRef) - prefer template bindings and signals."
+                });
+            }
+
+            return findings;
+        }
+    }
+}

--- a/src/Phase5-ASPtoAngular/Frontend/AspExpressionToTypeScript.cs
+++ b/src/Phase5-ASPtoAngular/Frontend/AspExpressionToTypeScript.cs
@@ -1,0 +1,92 @@
+using BLML.Phase1Foundation.AST;
+
+namespace BLML.Phase5ASPtoAngular.Frontend
+{
+    /// <summary>
+    /// Renders a VBScript expression (as parsed by VBScriptParser) as a TypeScript
+    /// expression for use inside an Angular template or component. Scoped to the
+    /// constructs that actually appear in presentation-classified expressions
+    /// (BusinessLogicExtractor has already routed data-access/session work
+    /// elsewhere) - anything it doesn't recognize renders as an inline TODO comment
+    /// rather than silently emitting something plausible-but-wrong.
+    ///
+    /// The one recordset-specific rule: inside a converted recordset loop, `rsVar("Field")`
+    /// becomes `loopItemVar.field` - the direct translation of ASP's classic
+    /// `rs("Field")` pattern into the `@for (item of items(); track item.id)` shape
+    /// TemplateConverter generates for `While Not rs.EOF ... Wend`.
+    /// </summary>
+    public class AspExpressionToTypeScript
+    {
+        /// <summary>Maps a recordset variable name (e.g. "rs") to the loop item variable currently in scope (e.g. "item"), if any.</summary>
+        public Dictionary<string, string> RecordsetLoopVariables { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public string Convert(ExpressionNode expr)
+        {
+            switch (expr)
+            {
+                case LiteralExpressionNode lit:
+                    return ConvertLiteral(lit);
+
+                case IdentifierExpressionNode id:
+                    return ToCamelCase(id.Name);
+
+                case InvocationExpressionNode inv when TryConvertRecordsetFieldAccess(inv, out var fieldAccess):
+                    return fieldAccess!;
+
+                case InvocationExpressionNode inv:
+                    return $"{Convert(inv.Target)}({string.Join(", ", inv.Arguments.Select(Convert))})";
+
+                case BinaryExpressionNode { Operator: "Not" } notExpr:
+                    return $"!({Convert(notExpr.Right)})";
+
+                case BinaryExpressionNode { Operator: "." } member:
+                    return $"{Convert(member.Left)}.{ConvertMemberName(member.Right)}";
+
+                case BinaryExpressionNode bin:
+                    return $"({Convert(bin.Left)} {MapOperator(bin.Operator)} {Convert(bin.Right)})";
+
+                default:
+                    return $"/* TODO: manual conversion needed */ null";
+            }
+        }
+
+        private bool TryConvertRecordsetFieldAccess(InvocationExpressionNode inv, out string? result)
+        {
+            result = null;
+            if (inv.Target is not IdentifierExpressionNode id) return false;
+            if (!RecordsetLoopVariables.TryGetValue(id.Name, out var loopVar)) return false;
+            if (inv.Arguments.Count != 1 || inv.Arguments[0] is not LiteralExpressionNode { Value: string field }) return false;
+            result = $"{loopVar}.{ToCamelCase(field)}";
+            return true;
+        }
+
+        private static string ConvertMemberName(ExpressionNode member) =>
+            member is IdentifierExpressionNode id ? ToCamelCase(id.Name) : "unknown";
+
+        private static string ConvertLiteral(LiteralExpressionNode lit) => lit.Value switch
+        {
+            null => "null",
+            bool b => b ? "true" : "false",
+            string s => $"'{s.Replace("\\", "\\\\").Replace("'", "\\'")}'",
+            _ => lit.Value.ToString() ?? "null"
+        };
+
+        private static string MapOperator(string op) => op switch
+        {
+            "&" => "+",
+            "=" => "===",
+            "<>" => "!==",
+            "And" => "&&",
+            "Or" => "||",
+            "Mod" => "%",
+            "\\" => "/", // integer division has no direct TS operator; nearest equivalent, flagged separately by the anti-pattern checker is out of scope here
+            _ => op
+        };
+
+        public static string ToCamelCase(string name)
+        {
+            if (string.IsNullOrEmpty(name)) return name;
+            return char.ToLowerInvariant(name[0]) + name[1..];
+        }
+    }
+}

--- a/src/Phase5-ASPtoAngular/Frontend/ComponentGenerator.cs
+++ b/src/Phase5-ASPtoAngular/Frontend/ComponentGenerator.cs
@@ -1,10 +1,111 @@
+using System.Text;
+
 namespace BLML.Phase5ASPtoAngular.Frontend
 {
+    public class GeneratedComponent
+    {
+        public string TypeScript { get; set; } = string.Empty;
+        public string Html { get; set; } = string.Empty;
+        public string Spec { get; set; } = string.Empty;
+        public List<AntiPatternFinding> Findings { get; } = new();
+    }
+
+    /// <summary>
+    /// Emits a standalone Angular component (no NgModule) in the modern Angular 17+
+    /// house style this whole generator targets: `inject()` for DI (never
+    /// constructor-parameter injection), `toSignal()` over an HttpClient call for
+    /// server-derived list state (never a raw `.subscribe()`), and the template
+    /// TemplateConverter already renders with `@if`/`@for`. Every component this
+    /// produces is run back through AngularAntiPatternChecker before being returned,
+    /// so a regression here fails loudly in ComponentGenerator's own tests instead of
+    /// shipping.
+    /// </summary>
     public class ComponentGenerator
     {
-        public string GenerateComponent(string name)
+        private readonly AngularAntiPatternChecker _checker = new();
+
+        public GeneratedComponent GenerateComponent(
+            string componentClassName,
+            string selector,
+            string apiResourcePath,
+            string dtoInterfaceName,
+            string templateHtml,
+            IReadOnlyList<string>? recordsetSignalNames = null)
         {
-            return $"@Component({{\n  selector: 'app-{name.ToLower()}',\n  templateUrl: './{name.ToLower()}.component.html'\n}})";
+            recordsetSignalNames ??= Array.Empty<string>();
+
+            var ts = new StringBuilder();
+            ts.AppendLine("import { Component, inject } from '@angular/core';");
+            ts.AppendLine("import { HttpClient } from '@angular/common/http';");
+            ts.AppendLine("import { toSignal } from '@angular/core/rxjs-interop';");
+            ts.AppendLine($"import {{ {dtoInterfaceName} }} from './{ToKebabCase(dtoInterfaceName)}.model';");
+            ts.AppendLine();
+            ts.AppendLine("@Component({");
+            ts.AppendLine($"  selector: '{selector}',");
+            ts.AppendLine("  standalone: true,");
+            ts.AppendLine($"  templateUrl: './{ToKebabCase(componentClassName)}.component.html'");
+            ts.AppendLine("})");
+            ts.AppendLine($"export class {componentClassName} {{");
+            ts.AppendLine("  private readonly http = inject(HttpClient);");
+            ts.AppendLine();
+            foreach (var signalName in recordsetSignalNames)
+            {
+                ts.AppendLine($"  readonly {signalName} = toSignal(");
+                ts.AppendLine($"    this.http.get<{dtoInterfaceName}[]>('{apiResourcePath}'),");
+                ts.AppendLine($"    {{ initialValue: [] as {dtoInterfaceName}[] }}");
+                ts.AppendLine("  );");
+                ts.AppendLine();
+            }
+            ts.AppendLine("}");
+
+            var spec = new StringBuilder();
+            spec.AppendLine("import { TestBed } from '@angular/core/testing';");
+            spec.AppendLine("import { provideHttpClientTesting } from '@angular/common/http/testing';");
+            spec.AppendLine("import { provideHttpClient } from '@angular/common/http';");
+            spec.AppendLine($"import {{ {componentClassName} }} from './{ToKebabCase(componentClassName)}.component';");
+            spec.AppendLine();
+            spec.AppendLine($"describe('{componentClassName}', () => {{");
+            spec.AppendLine("  beforeEach(() => TestBed.configureTestingModule({");
+            spec.AppendLine($"    imports: [{componentClassName}],");
+            spec.AppendLine("    providers: [provideHttpClient(), provideHttpClientTesting()]");
+            spec.AppendLine("  }));");
+            spec.AppendLine();
+            spec.AppendLine("  it('should create', () => {");
+            spec.AppendLine($"    const fixture = TestBed.createComponent({componentClassName});");
+            spec.AppendLine("    expect(fixture.componentInstance).toBeTruthy();");
+            spec.AppendLine("  });");
+            spec.AppendLine("});");
+
+            var result = new GeneratedComponent { TypeScript = ts.ToString(), Html = templateHtml, Spec = spec.ToString() };
+            result.Findings.AddRange(_checker.CheckComponent(result.TypeScript));
+            result.Findings.AddRange(_checker.CheckTemplate(result.Html));
+            return result;
+        }
+
+        public string GenerateDtoInterface(string interfaceName, IReadOnlyList<string> fieldNames)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine($"export interface {interfaceName} {{");
+            foreach (var field in fieldNames)
+            {
+                sb.AppendLine($"  {AspExpressionToTypeScript.ToCamelCase(field)}: unknown; // TODO: verify type - inferred from ASP `rs(\"{field}\")` usage, no schema was available.");
+            }
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+
+        public static string ToKebabCase(string pascalOrCamel)
+        {
+            var sb = new StringBuilder();
+            for (int i = 0; i < pascalOrCamel.Length; i++)
+            {
+                var c = pascalOrCamel[i];
+                if (char.IsUpper(c) && i > 0) sb.Append('-');
+                sb.Append(char.ToLowerInvariant(c));
+            }
+            var result = sb.ToString();
+            const string suffix = "-component";
+            return result.EndsWith(suffix) ? result[..^suffix.Length] : result;
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/Frontend/FormConverter.cs
+++ b/src/Phase5-ASPtoAngular/Frontend/FormConverter.cs
@@ -1,11 +1,180 @@
+using System.Text;
+using BLML.Phase1Foundation.AST;
+using BLML.Phase5ASPtoAngular.AspParser;
+
 namespace BLML.Phase5ASPtoAngular.Frontend
 {
+    public class FormFieldSpec
+    {
+        public string Name { get; set; } = string.Empty;
+        public bool Required { get; set; }
+        public bool LooksLikeEmail { get; set; }
+    }
+
+    public class FormConversionResult
+    {
+        public List<FormFieldSpec> Fields { get; } = new();
+        public List<string> Warnings { get; } = new();
+        public string TypeScript { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Converts an ASP form-handling page (fields read via `Request.Form("x")`, with
+    /// any inline emptiness checks treated as the ASP equivalent of `required`) into a
+    /// typed Angular Reactive Form - never `[(ngModel)]`, per this generator's house
+    /// style (see AngularAntiPatternChecker).
+    ///
+    /// Classic ASP ambiguity handled here: bare `Request("x")` (no `.Form`/
+    /// `.QueryString`/`.Cookies` qualifier) actually searches QueryString, Form,
+    /// Cookies, ServerVariables, and ClientCertificate, in that order - there's no way
+    /// to know which collection a given call actually meant without knowing which
+    /// collections were populated at runtime. This treats an unqualified read as a
+    /// form field (FormConverter's whole job), but records a warning per site instead
+    /// of silently guessing.
+    /// </summary>
     public class FormConverter
     {
-        public string ConvertForm(string htmlForm)
+        public FormConversionResult Convert(IEnumerable<StatementNode> statements, string formTypeName)
         {
-            // Extract inputs and create Reactive Form
-            return "";
+            var result = new FormConversionResult();
+            var fieldNames = new List<string>();
+            CollectRequestFields(statements, fieldNames, result.Warnings);
+
+            var fields = fieldNames.Select(name => new FormFieldSpec
+            {
+                Name = name,
+                Required = FieldIsCheckedForEmptiness(statements, name),
+                LooksLikeEmail = name.Contains("email", StringComparison.OrdinalIgnoreCase)
+            }).ToList();
+            result.Fields.AddRange(fields);
+            result.TypeScript = GenerateFormTypeScript(formTypeName, fields);
+            return result;
+        }
+
+        private static void CollectRequestFields(IEnumerable<StatementNode> statements, List<string> fields, List<string> warnings)
+        {
+            foreach (var expr in EnumerateExpressions(statements))
+            {
+                if (expr is not InvocationExpressionNode inv) continue;
+                if (inv.Arguments.Count != 1 || inv.Arguments[0] is not LiteralExpressionNode { Value: string fieldName }) continue;
+
+                bool isBareRequest = inv.Target is IdentifierExpressionNode bareId && string.Equals(bareId.Name, "Request", StringComparison.OrdinalIgnoreCase);
+                bool isRequestForm = inv.Target is BinaryExpressionNode { Operator: "." } member
+                    && member.Left is IdentifierExpressionNode owner && string.Equals(owner.Name, "Request", StringComparison.OrdinalIgnoreCase)
+                    && member.Right is IdentifierExpressionNode prop && string.Equals(prop.Name, "Form", StringComparison.OrdinalIgnoreCase);
+
+                if (isBareRequest)
+                {
+                    warnings.Add($"`Request(\"{fieldName}\")` is ambiguous in classic ASP (checks QueryString, Form, Cookies, ServerVariables, ClientCertificate in that order) - treated as a form field; verify this wasn't actually reading the query string.");
+                }
+
+                if ((isBareRequest || isRequestForm) && !fields.Contains(fieldName, StringComparer.OrdinalIgnoreCase))
+                {
+                    fields.Add(fieldName);
+                }
+            }
+        }
+
+        /// <summary>Heuristic: an `If Request.Form("x") = "" Then ...error...` (or `<>`) guard near the field read is treated as that field being required.</summary>
+        private static bool FieldIsCheckedForEmptiness(IEnumerable<StatementNode> statements, string fieldName)
+        {
+            foreach (var condition in EnumerateConditions(statements))
+            {
+                if (condition is not BinaryExpressionNode { Operator: "=" or "<>" } bin) continue;
+                if (IsRequestFieldRead(bin.Left, fieldName) && IsEmptyStringLiteral(bin.Right)) return true;
+                if (IsRequestFieldRead(bin.Right, fieldName) && IsEmptyStringLiteral(bin.Left)) return true;
+            }
+            return false;
+        }
+
+        private static bool IsRequestFieldRead(ExpressionNode expr, string fieldName)
+        {
+            if (expr is not InvocationExpressionNode inv) return false;
+            if (inv.Arguments.Count != 1 || inv.Arguments[0] is not LiteralExpressionNode { Value: string f }) return false;
+            if (!string.Equals(f, fieldName, StringComparison.OrdinalIgnoreCase)) return false;
+            return inv.Target is IdentifierExpressionNode { Name: "Request" }
+                || (inv.Target is BinaryExpressionNode { Operator: "." } m && m.Left is IdentifierExpressionNode { Name: "Request" });
+        }
+
+        private static bool IsEmptyStringLiteral(ExpressionNode expr) => expr is LiteralExpressionNode { Value: string s } && s.Length == 0;
+
+        private static IEnumerable<ExpressionNode> EnumerateConditions(IEnumerable<StatementNode> statements)
+        {
+            foreach (var stmt in statements)
+            {
+                switch (stmt)
+                {
+                    case IfStatementNode i:
+                        yield return i.Condition;
+                        foreach (var c in EnumerateConditions(i.TrueBlock.Statements)) yield return c;
+                        if (i.ElseBlock != null) foreach (var c in EnumerateConditions(i.ElseBlock.Statements)) yield return c;
+                        break;
+                    case SingleLineIfStatementNode s:
+                        yield return s.Condition;
+                        break;
+                }
+            }
+        }
+
+        private static IEnumerable<ExpressionNode> EnumerateExpressions(IEnumerable<StatementNode> statements)
+        {
+            foreach (var stmt in statements)
+            {
+                IEnumerable<ExpressionNode> here = stmt switch
+                {
+                    AssignmentNode a => new[] { a.Value },
+                    CallStatementNode c => new[] { c.Invocation },
+                    AspOutputExpressionStatementNode o => new[] { o.Expression },
+                    IfStatementNode i => new[] { i.Condition },
+                    SingleLineIfStatementNode s => new[] { s.Condition },
+                    _ => Enumerable.Empty<ExpressionNode>()
+                };
+                foreach (var e in here) foreach (var sub in Flatten(e)) yield return sub;
+
+                IEnumerable<StatementNode>? nested = stmt switch
+                {
+                    IfStatementNode i => i.ElseBlock is null ? i.TrueBlock.Statements : i.TrueBlock.Statements.Concat(i.ElseBlock.Statements),
+                    SingleLineIfStatementNode s => s.ElseStatement is null ? new[] { s.ThenStatement } : new[] { s.ThenStatement, s.ElseStatement },
+                    _ => null
+                };
+                if (nested != null) foreach (var e in EnumerateExpressions(nested)) yield return e;
+            }
+        }
+
+        private static IEnumerable<ExpressionNode> Flatten(ExpressionNode expr)
+        {
+            yield return expr;
+            if (expr is BinaryExpressionNode bin)
+            {
+                if (bin.Left != null) foreach (var e in Flatten(bin.Left)) yield return e;
+                if (bin.Right != null) foreach (var e in Flatten(bin.Right)) yield return e;
+            }
+            else if (expr is InvocationExpressionNode inv)
+            {
+                foreach (var e in Flatten(inv.Target)) yield return e;
+                foreach (var arg in inv.Arguments) foreach (var e in Flatten(arg)) yield return e;
+            }
+        }
+
+        private static string GenerateFormTypeScript(string formTypeName, List<FormFieldSpec> fields)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("import { inject } from '@angular/core';");
+            sb.AppendLine("import { FormBuilder, Validators } from '@angular/forms';");
+            sb.AppendLine();
+            sb.AppendLine($"// Typed Reactive Form - no [(ngModel)], per this generator's house style.");
+            sb.AppendLine($"const fb = inject(FormBuilder);");
+            sb.AppendLine($"export const {formTypeName} = fb.group({{");
+            foreach (var field in fields)
+            {
+                var validators = new List<string>();
+                if (field.Required) validators.Add("Validators.required");
+                if (field.LooksLikeEmail) validators.Add("Validators.email");
+                var validatorsText = validators.Count > 0 ? $", validators: [{string.Join(", ", validators)}]" : "";
+                sb.AppendLine($"  {AspExpressionToTypeScript.ToCamelCase(field.Name)}: fb.control('', {{ nonNullable: true{validatorsText} }}),");
+            }
+            sb.AppendLine("});");
+            return sb.ToString();
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/Frontend/RoutingGenerator.cs
+++ b/src/Phase5-ASPtoAngular/Frontend/RoutingGenerator.cs
@@ -1,11 +1,54 @@
+using System.Text;
+using BLML.Phase5ASPtoAngular.Analysis;
+
 namespace BLML.Phase5ASPtoAngular.Frontend
 {
+    /// <summary>
+    /// Turns PageFlowAnalyzer's page graph into a standalone Angular route table
+    /// (`provideRouter(routes)`, lazy `loadComponent` per route - no NgModule-based
+    /// lazy loading, matching this generator's standalone-only house style). One ASP
+    /// page name is treated as the home page and mapped to the empty path with the
+    /// rest redirecting to it as a catch-all.
+    /// </summary>
     public class RoutingGenerator
     {
-        public string GenerateRouting()
+        public string GenerateRoutes(IEnumerable<PageFlowEdge> edges, string homePageName)
         {
-            // Generate app-routing.module.ts content
-            return "";
+            var pages = new List<string> { homePageName };
+            foreach (var edge in edges)
+            {
+                if (!pages.Contains(edge.FromPage, StringComparer.OrdinalIgnoreCase)) pages.Add(edge.FromPage);
+                if (!pages.Contains(edge.ToPage, StringComparer.OrdinalIgnoreCase)) pages.Add(edge.ToPage);
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine("import { Routes } from '@angular/router';");
+            sb.AppendLine();
+            sb.AppendLine("export const routes: Routes = [");
+            foreach (var page in pages)
+            {
+                var folder = ToRouteSegment(page);
+                var className = ToComponentClassName(page);
+                var path = string.Equals(page, homePageName, StringComparison.OrdinalIgnoreCase) ? "" : folder;
+                sb.AppendLine($"  {{ path: '{path}', loadComponent: () => import('./{folder}/{folder}.component').then(m => m.{className}) }},");
+            }
+            sb.AppendLine("  { path: '**', redirectTo: '' }");
+            sb.AppendLine("];");
+            return sb.ToString();
+        }
+
+        private static string ToRouteSegment(string pageName)
+        {
+            var name = pageName.EndsWith(".asp", StringComparison.OrdinalIgnoreCase) ? pageName[..^4] : pageName;
+            return ComponentGenerator.ToKebabCase(name);
+        }
+
+        private static string ToComponentClassName(string pageName)
+        {
+            var segment = ToRouteSegment(pageName);
+            var parts = segment.Split('-', StringSplitOptions.RemoveEmptyEntries);
+            var pascal = string.Concat(parts.Select(p => char.ToUpperInvariant(p[0]) + p[1..]));
+            return pascal + "Component";
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/Frontend/TemplateConverter.cs
+++ b/src/Phase5-ASPtoAngular/Frontend/TemplateConverter.cs
@@ -1,11 +1,197 @@
+using System.Text;
+using BLML.Phase1Foundation.AST;
+using BLML.Phase5ASPtoAngular.AspParser;
+
 namespace BLML.Phase5ASPtoAngular.Frontend
 {
+    /// <summary>
+    /// Converts a parsed ASP page's statement tree into an Angular template, using the
+    /// modern (Angular 17+) built-in control-flow syntax - `@if`/`@else if`/`@else` and
+    /// `@for ( ; track ...)` - rather than the older `*ngIf`/`*ngFor` structural
+    /// directives, since that's both the current Angular default and what
+    /// AngularAntiPatternChecker enforces on every generator's own output.
+    ///
+    /// The classic ASP recordset loop (`While Not rs.EOF ... rs.MoveNext ... Wend`,
+    /// the exact pattern documented in ProjectPlan.md's "Data Binding Patterns"
+    /// section) is recognized specifically and rendered as `@for (item of
+    /// xItems(); track item.id)`; `rs.MoveNext` is loop mechanics with no template
+    /// equivalent and is dropped rather than mistranslated.
+    /// </summary>
     public class TemplateConverter
     {
-        public string ConvertTemplate(string html)
+        public List<string> Warnings { get; } = new();
+
+        public string Convert(IEnumerable<StatementNode> statements)
         {
-            // PRO TIP: Convert <% %> to {{ }} or *ngIf
-            return html;
+            var exprConverter = new AspExpressionToTypeScript();
+            var sb = new StringBuilder();
+            ConvertStatements(statements, sb, exprConverter);
+            return sb.ToString();
+        }
+
+        private void ConvertStatements(IEnumerable<StatementNode> statements, StringBuilder sb, AspExpressionToTypeScript exprConverter)
+        {
+            foreach (var stmt in statements)
+            {
+                switch (stmt)
+                {
+                    case HtmlOutputStatementNode html:
+                        sb.Append(html.Html);
+                        break;
+
+                    case AspOutputExpressionStatementNode output:
+                        sb.Append("{{ ").Append(exprConverter.Convert(output.Expression)).Append(" }}");
+                        break;
+
+                    case CallStatementNode call when IsRecordsetMoveNext(call, exprConverter):
+                        // loop mechanics - no template equivalent
+                        break;
+
+                    case CallStatementNode call when TryGetResponseWriteArgument(call, out var writeExpr):
+                        sb.Append("{{ ").Append(exprConverter.Convert(writeExpr!)).Append(" }}");
+                        break;
+
+                    case CallStatementNode:
+                        // business logic, not presentation - nothing to render
+                        break;
+
+                    case AssignmentNode:
+                        // business logic, not presentation - nothing to render
+                        break;
+
+                    case IfStatementNode ifStmt:
+                        ConvertIf(ifStmt, sb, exprConverter, isFirst: true);
+                        break;
+
+                    case SingleLineIfStatementNode single:
+                        sb.Append("@if (").Append(exprConverter.Convert(single.Condition)).Append(") {\n");
+                        ConvertStatements(new[] { single.ThenStatement }, sb, exprConverter);
+                        sb.Append("\n}");
+                        if (single.ElseStatement != null)
+                        {
+                            sb.Append(" @else {\n");
+                            ConvertStatements(new[] { single.ElseStatement }, sb, exprConverter);
+                            sb.Append("\n}");
+                        }
+                        break;
+
+                    case WhileStatementNode whileStmt when TryGetRecordsetLoopVariable(whileStmt.Condition, out var rsVar):
+                        ConvertRecordsetLoop(whileStmt, rsVar!, sb, exprConverter);
+                        break;
+
+                    case WhileStatementNode whileStmt:
+                        Warnings.Add("A While loop that isn't a recognized `While Not rs.EOF` recordset pattern was found in presentation code; rendering as @for over its condition is not supported, statement skipped.");
+                        break;
+
+                    case ForStatementNode forStmt:
+                        sb.Append("@for (").Append(AspExpressionToTypeScript.ToCamelCase(forStmt.LoopVariable))
+                          .Append(" of range(").Append(exprConverter.Convert(forStmt.StartValue)).Append(", ")
+                          .Append(exprConverter.Convert(forStmt.EndValue)).Append("); track $index) {\n");
+                        ConvertStatements(forStmt.Body.Statements, sb, exprConverter);
+                        sb.Append("\n}");
+                        break;
+
+                    case ForEachStatementNode forEach:
+                        var loopVar = AspExpressionToTypeScript.ToCamelCase(forEach.LoopVariable);
+                        sb.Append("@for (").Append(loopVar).Append(" of ").Append(exprConverter.Convert(forEach.Collection))
+                          .Append("; track $index) {\n");
+                        ConvertStatements(forEach.Body.Statements, sb, exprConverter);
+                        sb.Append("\n}");
+                        break;
+
+                    case SelectCaseStatementNode select:
+                        ConvertSelectCase(select, sb, exprConverter);
+                        break;
+
+                    case DoLoopStatementNode doLoop:
+                        Warnings.Add("A Do/Loop was found in presentation code; classic ASP rarely uses Do/Loop for row iteration and no template mapping is defined, statement skipped.");
+                        break;
+                }
+            }
+        }
+
+        private void ConvertIf(IfStatementNode ifStmt, StringBuilder sb, AspExpressionToTypeScript exprConverter, bool isFirst)
+        {
+            sb.Append(isFirst ? "@if (" : "@else if (").Append(exprConverter.Convert(ifStmt.Condition)).Append(") {\n");
+            ConvertStatements(ifStmt.TrueBlock.Statements, sb, exprConverter);
+            sb.Append("\n}");
+
+            if (ifStmt.ElseBlock is { Statements.Count: 1 } && ifStmt.ElseBlock.Statements[0] is IfStatementNode nestedElseIf)
+            {
+                sb.Append(' ');
+                ConvertIf(nestedElseIf, sb, exprConverter, isFirst: false);
+            }
+            else if (ifStmt.ElseBlock != null)
+            {
+                sb.Append(" @else {\n");
+                ConvertStatements(ifStmt.ElseBlock.Statements, sb, exprConverter);
+                sb.Append("\n}");
+            }
+        }
+
+        private void ConvertSelectCase(SelectCaseStatementNode select, StringBuilder sb, AspExpressionToTypeScript exprConverter)
+        {
+            var testExprText = exprConverter.Convert(select.TestExpression);
+            bool first = true;
+            foreach (var clause in select.Cases)
+            {
+                var conditionText = string.Join(" || ", clause.Values.Select(v => $"{testExprText} === {exprConverter.Convert(v)}"));
+                sb.Append(first ? "@if (" : "@else if (").Append(conditionText).Append(") {\n");
+                ConvertStatements(clause.Body.Statements, sb, exprConverter);
+                sb.Append("\n}");
+                first = false;
+            }
+            if (select.CaseElseBlock != null)
+            {
+                sb.Append(" @else {\n");
+                ConvertStatements(select.CaseElseBlock.Statements, sb, exprConverter);
+                sb.Append("\n}");
+            }
+        }
+
+        private void ConvertRecordsetLoop(WhileStatementNode whileStmt, string rsVar, StringBuilder sb, AspExpressionToTypeScript exprConverter)
+        {
+            var itemsSignal = AspExpressionToTypeScript.ToCamelCase(rsVar) + "Items";
+            exprConverter.RecordsetLoopVariables[rsVar] = "item";
+
+            sb.Append("@for (item of ").Append(itemsSignal).Append("(); track item.id) {\n");
+            ConvertStatements(whileStmt.Body.Statements, sb, exprConverter);
+            sb.Append("\n}");
+
+            exprConverter.RecordsetLoopVariables.Remove(rsVar);
+        }
+
+        /// <summary>Matches the `While Not rs.EOF` loop guard and returns the recordset variable name.</summary>
+        private static bool TryGetRecordsetLoopVariable(ExpressionNode condition, out string? rsVar)
+        {
+            rsVar = null;
+            if (condition is not BinaryExpressionNode { Operator: "Not" } notExpr) return false;
+            if (notExpr.Right is not BinaryExpressionNode { Operator: "." } member) return false;
+            if (member.Left is not IdentifierExpressionNode id) return false;
+            if (member.Right is not IdentifierExpressionNode prop || !string.Equals(prop.Name, "EOF", StringComparison.OrdinalIgnoreCase)) return false;
+            rsVar = id.Name;
+            return true;
+        }
+
+        private static bool IsRecordsetMoveNext(CallStatementNode call, AspExpressionToTypeScript exprConverter)
+        {
+            if (call.Invocation is not InvocationExpressionNode inv) return false;
+            if (inv.Target is not BinaryExpressionNode { Operator: "." } member) return false;
+            if (member.Left is not IdentifierExpressionNode id) return false;
+            if (member.Right is not IdentifierExpressionNode method || !string.Equals(method.Name, "MoveNext", StringComparison.OrdinalIgnoreCase)) return false;
+            return exprConverter.RecordsetLoopVariables.ContainsKey(id.Name);
+        }
+
+        private static bool TryGetResponseWriteArgument(CallStatementNode call, out ExpressionNode? argument)
+        {
+            argument = null;
+            if (call.Invocation is not InvocationExpressionNode inv) return false;
+            if (inv.Target is not BinaryExpressionNode { Operator: "." } member) return false;
+            if (member.Left is not IdentifierExpressionNode owner || !string.Equals(owner.Name, "Response", StringComparison.OrdinalIgnoreCase)) return false;
+            if (member.Right is not IdentifierExpressionNode method || !string.Equals(method.Name, "Write", StringComparison.OrdinalIgnoreCase)) return false;
+            if (inv.Arguments.Count == 0) return false;
+            argument = inv.Arguments[0];
+            return true;
         }
     }
 }

--- a/src/Phase5-ASPtoAngular/README.md
+++ b/src/Phase5-ASPtoAngular/README.md
@@ -64,3 +64,28 @@ The existing prototype assets currently provide:
 - replace the current prototype scripts and placeholder templates with a real migration pipeline
 - add ASP/VBScript parsing, backend generation, and metadata-driven UI generation
 - move from documentation-only coverage to executable generation and validation of produced web artifacts
+
+## Platform decision: Angular (real pipeline added)
+
+The "make the platform decision" TODO above is resolved: **Angular**, per `ProjectPlan.md`. The
+`RazorPages/` prototype above is left in place as a historical artifact - nothing in it is part
+of the build, and it isn't superseded so much as simply not the direction taken.
+
+A real, tested ASP-to-Angular pipeline now exists alongside it:
+
+- `AspParser/` - a classic ASP/VBScript lexer and recursive-descent parser (`AspLexer`,
+  `VbScriptTokenizer`, `VBScriptParser`, `AspParser`, `IncludeFileResolver`, `GlobalAsaParser`)
+- `Analysis/` - `BusinessLogicExtractor`, `SessionVariableTracker`, `DatabaseCallAnalyzer`,
+  `PageFlowAnalyzer`
+- `Backend/` - `DtoGenerator`, `ServiceGenerator`, `ControllerGenerator`, `AuthConverter`,
+  `MiddlewareGenerator` (.NET 8 Web API)
+- `Frontend/` - `TemplateConverter`, `ComponentGenerator`, `FormConverter`, `RoutingGenerator`,
+  `AngularAntiPatternChecker` (standalone Angular 17+: `@if`/`@for`, `inject()`, signals, typed
+  Reactive Forms - see class-level docs on each type for the specific conventions and why)
+- `Database/` - `EFCoreGenerator`, `MigrationScripts`, `RepositoryGenerator` (delegate to the
+  already-implemented Phase 4 EF Core/schema generators rather than duplicating them)
+- `AspProjectConverter` ties all of the above into one pipeline, exposed via the CLI as
+  `convert-asp-project --input <folder-of-.asp-files> --output <folder>`
+
+See `tests/BLML.Tests/Phase5AspToAngularTests.cs` for coverage of each piece, including an
+end-to-end test that runs a small multi-page ASP app through the full pipeline.

--- a/src/Phase8-Tooling/CLI/CommandLineInterface.cs
+++ b/src/Phase8-Tooling/CLI/CommandLineInterface.cs
@@ -294,6 +294,33 @@ namespace BLML.Phase8Tooling.CLI
                 output.WriteLine($"Report written to {reportPath}");
                 return Task.FromResult((int)CliExitCode.OperationFailed);
             }
+            if (command == "convert-asp-project")
+            {
+                var input = ""; var outPath = "";
+                for (int i = 1; i < args.Length; i++)
+                {
+                    if (args[i] == "--input" && i + 1 < args.Length) input = args[++i];
+                    else if (args[i] == "--output" && i + 1 < args.Length) outPath = args[++i];
+                }
+
+                if (string.IsNullOrWhiteSpace(input) || !Directory.Exists(input))
+                {
+                    error.WriteLine("An input directory containing .asp files is required.");
+                    return Task.FromResult((int)CliExitCode.InputNotFound);
+                }
+
+                if (string.IsNullOrWhiteSpace(outPath))
+                {
+                    outPath = Path.Combine(input, "converted");
+                }
+
+                var converter = new BLML.Phase5ASPtoAngular.AspProjectConverter();
+                var result = converter.ConvertDirectory(input, outPath);
+
+                foreach (var warning in result.Warnings) output.WriteLine($"  WARNING: {warning}");
+                output.WriteLine($"[progress] Generated {result.GeneratedFiles.Count} files into {outPath}");
+                return Task.FromResult((int)CliExitCode.Success);
+            }
             if (command == "form-export")
             {
                 var input = ""; var outPath = "";

--- a/tests/BLML.Tests/Phase5AspToAngularTests.cs
+++ b/tests/BLML.Tests/Phase5AspToAngularTests.cs
@@ -5,11 +5,64 @@ using BLML.Phase5ASPtoAngular.Analysis;
 using BLML.Phase5ASPtoAngular.Backend.ApiGenerator;
 using BLML.Phase5ASPtoAngular.Backend.Infrastructure;
 using BLML.Phase5ASPtoAngular.Frontend;
+using BLML.Phase5ASPtoAngular.Database;
 
 namespace BLML.Tests
 {
     public class Phase5AspToAngularTests
     {
+        [Fact]
+        public void EFCoreGenerator_BuildsTableMetadataFromAspFieldUsageAndDelegatesToPhase4()
+        {
+            var asp = "<% Set rs = Server.CreateObject(\"ADODB.Recordset\") %>"
+                     + "<% rs.Open \"SELECT * FROM Products\", conn %>"
+                     + "<%= rs(\"Id\") %><%= rs(\"Name\") %>";
+            var page = new AspParser().Parse(asp);
+            var fields = new DatabaseCallAnalyzer().FindFieldReferences(page.Statements, "rs");
+
+            var generator = new EFCoreGenerator();
+            var table = generator.BuildTableMetadata("Products", fields, new[] { "Id" });
+            var entityOutput = generator.GenerateEntities(new[] { table });
+            var contextOutput = generator.GenerateDbContext("ApiDbContext", new List<BLML.Phase4DataAccess.Models.TableMetadata> { table });
+
+            Assert.Contains("public class Products", entityOutput);
+            Assert.Contains("public string Id { get; set; }", entityOutput); // Phase4's EntityGenerator maps our "string" placeholder type through as-is
+            Assert.Contains("public class ApiDbContext : DbContext", contextOutput);
+        }
+
+        [Fact]
+        public void MigrationScripts_DelegatesToPhase4SchemaAndBulkCopyGenerators()
+        {
+            var table = new BLML.Phase4DataAccess.Models.TableMetadata
+            {
+                Name = "Products",
+                Columns = { new BLML.Phase4DataAccess.Models.ColumnMetadata { Name = "Id", DataType = "int", IsNullable = false } },
+                PrimaryKeyColumns = { "Id" }
+            };
+
+            var scripts = new MigrationScripts();
+            var createScript = scripts.GenerateCreateScripts(new[] { table });
+            var bulkCopyScript = scripts.GenerateBulkCopyScripts(new[] { table });
+
+            Assert.Contains("CREATE TABLE [Products]", createScript);
+            Assert.Contains("MigrateProducts", bulkCopyScript);
+            Assert.Contains("SqlBulkCopy", bulkCopyScript);
+        }
+
+        [Fact]
+        public void RepositoryGenerator_EmitsCrudInterfaceAndImplementationOverTheGeneratedDbContext()
+        {
+            var table = new BLML.Phase4DataAccess.Models.TableMetadata { Name = "Products", PrimaryKeyColumns = { "Id" } };
+
+            var generator = new RepositoryGenerator();
+            var iface = generator.GenerateRepositoryInterface(table);
+            var impl = generator.GenerateRepositoryImplementation(table, "ApiDbContext");
+
+            Assert.Contains("interface IProductsRepository", iface);
+            Assert.Contains("class ProductsRepository : IProductsRepository", impl);
+            Assert.Contains("private readonly ApiDbContext _context", impl);
+            Assert.Contains("await _context.SaveChangesAsync();", impl);
+        }
         [Fact]
         public void TemplateConverter_RendersClassicRecordsetLoopAsForWithTrackAndFieldAccess()
         {

--- a/tests/BLML.Tests/Phase5AspToAngularTests.cs
+++ b/tests/BLML.Tests/Phase5AspToAngularTests.cs
@@ -4,11 +4,118 @@ using BLML.Phase5ASPtoAngular.AspParser;
 using BLML.Phase5ASPtoAngular.Analysis;
 using BLML.Phase5ASPtoAngular.Backend.ApiGenerator;
 using BLML.Phase5ASPtoAngular.Backend.Infrastructure;
+using BLML.Phase5ASPtoAngular.Frontend;
 
 namespace BLML.Tests
 {
     public class Phase5AspToAngularTests
     {
+        [Fact]
+        public void TemplateConverter_RendersClassicRecordsetLoopAsForWithTrackAndFieldAccess()
+        {
+            var asp = "<% While Not rs.EOF %><tr><td><%=rs(\"Name\")%></td></tr><% rs.MoveNext %><% Wend %>";
+            var page = new AspParser().Parse(asp);
+
+            var html = new TemplateConverter().Convert(page.Statements);
+
+            Assert.Contains("@for (item of rsItems(); track item.id)", html);
+            Assert.Contains("{{ item.name }}", html);
+            Assert.DoesNotContain("MoveNext", html); // loop mechanics dropped, not mistranslated
+        }
+
+        [Fact]
+        public void TemplateConverter_RendersElseIfChainAsAtElseIf()
+        {
+            var asp = "<% If x = 1 Then %>A<% ElseIf x = 2 Then %>B<% Else %>C<% End If %>";
+            var page = new AspParser().Parse(asp);
+
+            var html = new TemplateConverter().Convert(page.Statements);
+
+            Assert.Contains("@if (", html);
+            Assert.Contains("@else if (", html);
+            Assert.Contains("@else {", html);
+            Assert.Contains("A", html);
+            Assert.Contains("B", html);
+            Assert.Contains("C", html);
+        }
+
+        [Fact]
+        public void TemplateConverter_TranslatesResponseWriteToInterpolation()
+        {
+            var asp = "<% Response.Write name %>";
+            var page = new AspParser().Parse(asp);
+
+            var html = new TemplateConverter().Convert(page.Statements);
+
+            Assert.Contains("{{ name }}", html);
+        }
+
+        [Fact]
+        public void AngularAntiPatternChecker_FlagsEveryTargetedLegacyPattern()
+        {
+            var checker = new AngularAntiPatternChecker();
+
+            var templateFindings = checker.CheckTemplate("<div *ngIf=\"x\"></div>@for (x of items) { {{x}} }<input [(ngModel)]=\"y\">");
+            Assert.Contains(templateFindings, f => f.Rule == "no-legacy-structural-directives");
+            Assert.Contains(templateFindings, f => f.Rule == "for-requires-track");
+            Assert.Contains(templateFindings, f => f.Rule == "no-ngmodel-two-way-binding");
+
+            var badComponent = "@NgModule({})\nexport class X {\n  constructor(private http: HttpClient) {}\n  load(): any { this.http.get('/x').subscribe(r => r); }\n  el = document.getElementById('x');\n}";
+            var componentFindings = checker.CheckComponent(badComponent);
+            Assert.Contains(componentFindings, f => f.Rule == "no-ngmodule");
+            Assert.Contains(componentFindings, f => f.Rule == "no-any-type");
+            Assert.Contains(componentFindings, f => f.Rule == "no-unmanaged-subscribe");
+            Assert.Contains(componentFindings, f => f.Rule == "prefer-inject-function");
+            Assert.Contains(componentFindings, f => f.Rule == "no-direct-dom-access");
+        }
+
+        [Fact]
+        public void ComponentGenerator_OwnOutputPassesTheAntiPatternChecker()
+        {
+            var generator = new ComponentGenerator();
+            var template = "@for (item of rsItems(); track item.id) { <li>{{ item.name }}</li> }";
+
+            var component = generator.GenerateComponent("ProductsComponent", "app-products", "/api/products", "ProductDto", template, new[] { "rsItems" });
+
+            Assert.Empty(component.Findings);
+            Assert.Contains("standalone: true", component.TypeScript);
+            Assert.Contains("inject(HttpClient)", component.TypeScript);
+            Assert.Contains("toSignal(", component.TypeScript);
+            Assert.DoesNotContain("constructor(", component.TypeScript);
+        }
+
+        [Fact]
+        public void FormConverter_InfersRequiredFromEmptyCheckAndFlagsAmbiguousBareRequestAccess()
+        {
+            var asp = "<% If Request.Form(\"Email\") = \"\" Then %>Missing<% End If %><% x = Request(\"Promo\") %>";
+            var page = new AspParser().Parse(asp);
+
+            var result = new FormConverter().Convert(page.Statements, "checkoutForm");
+
+            var email = result.Fields.Single(f => f.Name == "Email");
+            Assert.True(email.Required);
+            Assert.True(email.LooksLikeEmail);
+            Assert.Contains(result.Fields, f => f.Name == "Promo");
+            Assert.Contains(result.Warnings, w => w.Contains("ambiguous"));
+            Assert.Contains("Validators.required", result.TypeScript);
+            Assert.Contains("FormBuilder", result.TypeScript); // uses typed Reactive Forms, not template-driven ngModel binding
+        }
+
+        [Fact]
+        public void RoutingGenerator_PutsHomePageAtEmptyPathAndOthersAtKebabRoutes()
+        {
+            var edges = new List<PageFlowEdge>
+            {
+                new() { FromPage = "index.asp", ToPage = "productDetails.asp", Trigger = PageFlowTrigger.Link }
+            };
+
+            var routes = new RoutingGenerator().GenerateRoutes(edges, "index.asp");
+
+            Assert.Contains("{ path: '', loadComponent:", routes);
+            Assert.Contains("product-details", routes);
+            Assert.Contains("ProductDetailsComponent", routes);
+            Assert.Contains("{ path: '**', redirectTo: '' }", routes);
+        }
         [Fact]
         public void DtoGenerator_EmitsUntypedPropertiesWithVerifyTodoForEachAspField()
         {

--- a/tests/BLML.Tests/Phase5AspToAngularTests.cs
+++ b/tests/BLML.Tests/Phase5AspToAngularTests.cs
@@ -1,11 +1,73 @@
 using Xunit;
 using BLML.Phase1Foundation.AST;
 using BLML.Phase5ASPtoAngular.AspParser;
+using BLML.Phase5ASPtoAngular.Analysis;
 
 namespace BLML.Tests
 {
     public class Phase5AspToAngularTests
     {
+        [Fact]
+        public void GlobalAsaParser_ExtractsLifecycleEventsAndObjectDeclarations()
+        {
+            var content = @"
+<OBJECT RUNAT=Server SCOPE=Application ID=DbConn PROGID=""ADODB.Connection"">
+</OBJECT>
+<SCRIPT LANGUAGE=""VBScript"" RUNAT=""Server"">
+Sub Application_OnStart
+    Application(""Name"") = ""MyApp""
+End Sub
+
+Sub Session_OnStart
+    Session.Timeout = 20
+End Sub
+</SCRIPT>";
+
+            var page = new GlobalAsaParser().Parse(content);
+
+            Assert.NotNull(page.ApplicationOnStart);
+            Assert.NotNull(page.SessionOnStart);
+            Assert.Null(page.ApplicationOnEnd);
+            var obj = Assert.Single(page.Objects);
+            Assert.Equal("DbConn", obj.Id);
+            Assert.Equal("ADODB.Connection", obj.ProgId);
+            Assert.Equal("Application", obj.Scope);
+        }
+
+        [Fact]
+        public void BusinessLogicExtractor_SeparatesAdoWorkFromHtmlOutput()
+        {
+            var asp = "<% Set rs = Server.CreateObject(\"ADODB.Recordset\") %><h1>Title</h1><%= name %>";
+            var page = new AspParser().Parse(asp);
+
+            var classified = new BusinessLogicExtractor().Classify(page.Statements);
+
+            var adoStatement = classified.First(c => c.Statement is AssignmentNode);
+            Assert.Equal(StatementKind.BusinessLogic, adoStatement.Kind);
+
+            var htmlStatement = classified.First(c => c.Statement is HtmlOutputStatementNode);
+            Assert.Equal(StatementKind.Presentation, htmlStatement.Kind);
+
+            var outputStatement = classified.First(c => c.Statement is AspOutputExpressionStatementNode);
+            Assert.Equal(StatementKind.Presentation, outputStatement.Kind);
+        }
+
+        [Fact]
+        public void BusinessLogicExtractor_PropagatesClassificationThroughSimpleDefUseChain()
+        {
+            // userId is assigned from a Session read (business logic); a later
+            // assignment that only reads userId (no Session/Request/ADO marker of its
+            // own) should still inherit that classification, since the computation it
+            // performs belongs in the service layer alongside where userId came from.
+            var asp = "<% userId = Session(\"UserId\") %><% displayName = userId & \" (VIP)\" %>";
+            var page = new AspParser().Parse(asp);
+
+            var classified = new BusinessLogicExtractor().Classify(page.Statements);
+            var assignments = classified.Where(c => c.Statement is AssignmentNode).ToList();
+
+            Assert.Equal(2, assignments.Count);
+            Assert.All(assignments, a => Assert.Equal(StatementKind.BusinessLogic, a.Kind));
+        }
         [Fact]
         public void AspLexer_SplitsHtmlCodeAndOutputExpressionRegions()
         {

--- a/tests/BLML.Tests/Phase5AspToAngularTests.cs
+++ b/tests/BLML.Tests/Phase5AspToAngularTests.cs
@@ -2,11 +2,93 @@ using Xunit;
 using BLML.Phase1Foundation.AST;
 using BLML.Phase5ASPtoAngular.AspParser;
 using BLML.Phase5ASPtoAngular.Analysis;
+using BLML.Phase5ASPtoAngular.Backend.ApiGenerator;
+using BLML.Phase5ASPtoAngular.Backend.Infrastructure;
 
 namespace BLML.Tests
 {
     public class Phase5AspToAngularTests
     {
+        [Fact]
+        public void DtoGenerator_EmitsUntypedPropertiesWithVerifyTodoForEachAspField()
+        {
+            var output = new DtoGenerator().GenerateDto("ProductDto", new[] { "Id", "Name", "Price" });
+
+            Assert.Contains("public class ProductDto", output);
+            Assert.Contains("public object? Id { get; set; }", output);
+            Assert.Contains("public object? Name { get; set; }", output);
+            Assert.Contains("// TODO: verify type", output);
+        }
+
+        [Fact]
+        public void ServiceGenerator_AlwaysParameterizesEvenWhenSourceSqlWasConcatenated()
+        {
+            var asp = "<% Set rs = Server.CreateObject(\"ADODB.Recordset\") %>"
+                     + "<% rs.Open \"SELECT * FROM Products WHERE Id=\" & id, conn %>";
+            var page = new AspParser().Parse(asp);
+            var adoObjects = new DatabaseCallAnalyzer().Analyze(page.Statements);
+            var site = adoObjects.Single().CallSites.Single();
+            Assert.True(site.BuiltByUnsafeConcatenation); // confirm the source really was unsafe
+
+            var spec = new ServiceMethodSpec { MethodName = "GetProducts", Site = site, ResultFields = new[] { "Id", "Name" } };
+            var output = new ServiceGenerator().GenerateServiceClass("ProductService", "ProductDto", new[] { spec });
+
+            Assert.Contains("new SqlCommand(\"SELECT * FROM Products WHERE Id=@id\", connection)", output);
+            Assert.Contains("command.Parameters.AddWithValue(\"@id\", id)", output);
+            Assert.DoesNotContain("\" & id", output); // no leftover string concatenation of user input into SQL
+        }
+
+        [Fact]
+        public void ControllerGenerator_DerivesRestVerbFromSqlStatement()
+        {
+            Assert.Equal(("GET", false), ControllerGenerator.DeriveVerbFromSql("SELECT * FROM Products"));
+            Assert.Equal(("POST", true), ControllerGenerator.DeriveVerbFromSql("INSERT INTO Products (Name) VALUES (?)"));
+            Assert.Equal(("PUT", true), ControllerGenerator.DeriveVerbFromSql("UPDATE Products SET Name=?"));
+            Assert.Equal(("DELETE", true), ControllerGenerator.DeriveVerbFromSql("DELETE FROM Products WHERE Id=?"));
+        }
+
+        [Fact]
+        public void ControllerGenerator_EmitsRestConventionActionsWithCorrectStatusCodes()
+        {
+            var actions = new[]
+            {
+                new ControllerActionSpec { MethodName = "GetProducts", ServiceMethodName = "GetProducts", HttpVerb = "GET" },
+                new ControllerActionSpec { MethodName = "CreateProduct", ServiceMethodName = "CreateProduct", HttpVerb = "POST" }
+            };
+            var output = new ControllerGenerator().GenerateController("products", "ProductsController", "ProductService", "ProductDto", actions);
+
+            Assert.Contains("[Route(\"api/products\")]", output);
+            Assert.Contains("[HttpGet(", output);
+            Assert.Contains("[HttpPost]", output);
+            Assert.Contains("StatusCode(201)", output);
+        }
+
+        [Fact]
+        public void AuthConverter_NormalizesAllThreeNullCheckIdiomsToOneClaimsCheck()
+        {
+            var info = new SessionVariableInfo { Name = "UserId" };
+            info.NullCheckIdiomsObserved.Add(SessionNullCheckIdiom.EqualsEmptyString);
+            info.NullCheckIdiomsObserved.Add(SessionNullCheckIdiom.IsEmptyCall);
+            info.NullCheckIdiomsObserved.Add(SessionNullCheckIdiom.IsNothingComparison);
+
+            var check = new AuthConverter().GenerateNormalizedNullCheck(info);
+
+            Assert.Contains("User.HasClaim(c => c.Type == \"UserId\")", check);
+            // exactly one generated check regardless of how many idioms the source mixed
+            Assert.Equal(1, System.Text.RegularExpressions.Regex.Matches(check, "User\\.HasClaim").Count);
+        }
+
+        [Fact]
+        public void MiddlewareGenerator_WiresCorsJwtAndServiceRegistrationsIntoProgramCs()
+        {
+            var output = new MiddlewareGenerator().GenerateProgramCs(new[] { "ProductService" }, "https://localhost:4200");
+
+            Assert.Contains("AddScoped<ProductService>", output);
+            Assert.Contains("WithOrigins(\"https://localhost:4200\")", output);
+            Assert.Contains("AddJwtBearer", output);
+            Assert.Contains("app.UseAuthentication();", output);
+            Assert.Contains("app.UseAuthorization();", output);
+        }
         [Fact]
         public void SessionVariableTracker_CatalogsReadsWritesAndAllThreeNullCheckIdioms()
         {

--- a/tests/BLML.Tests/Phase5AspToAngularTests.cs
+++ b/tests/BLML.Tests/Phase5AspToAngularTests.cs
@@ -1,0 +1,192 @@
+using Xunit;
+using BLML.Phase1Foundation.AST;
+using BLML.Phase5ASPtoAngular.AspParser;
+
+namespace BLML.Tests
+{
+    public class Phase5AspToAngularTests
+    {
+        [Fact]
+        public void AspLexer_SplitsHtmlCodeAndOutputExpressionRegions()
+        {
+            var lexer = new AspLexer();
+            var regions = lexer.Tokenize("<html><% x = 1 %><%= x %></html>");
+
+            Assert.Equal(4, regions.Count);
+            Assert.Equal(AspRegionType.Html, regions[0].Type);
+            Assert.Equal("<html>", regions[0].Text);
+            Assert.Equal(AspRegionType.CodeBlock, regions[1].Type);
+            Assert.Equal("x = 1", regions[1].Text);
+            Assert.Equal(AspRegionType.OutputExpression, regions[2].Type);
+            Assert.Equal(AspRegionType.Html, regions[3].Type);
+            Assert.Equal("</html>", regions[3].Text);
+        }
+
+        [Fact]
+        public void AspLexer_DoesNotTreatPercentGreaterThanInsideStringAsBlockTerminator()
+        {
+            var lexer = new AspLexer();
+            var regions = lexer.Tokenize("<% s = \"50%>done\" %>");
+
+            var code = Assert.Single(regions.Where(r => r.Type == AspRegionType.CodeBlock));
+            Assert.Equal("s = \"50%>done\"", code.Text);
+        }
+
+        [Fact]
+        public void AspLexer_DetectsDirectiveAndServerComment()
+        {
+            var lexer = new AspLexer();
+            var regions = lexer.Tokenize("<%@ Language=\"VBScript\" %><%-- a comment --%>");
+
+            Assert.Equal(AspRegionType.Directive, regions[0].Type);
+            Assert.Equal(AspRegionType.ServerComment, regions[1].Type);
+        }
+
+        [Fact]
+        public void AspLexer_DistinguishesIncludeDirectiveFromOrdinaryHtmlComment()
+        {
+            var lexer = new AspLexer();
+            var regions = lexer.Tokenize("<!--#include file=\"header.asp\"--><!-- just a comment -->");
+
+            Assert.Equal(2, regions.Count);
+            Assert.Equal(AspRegionType.Include, regions[0].Type);
+            Assert.Equal("header.asp", regions[0].IncludePath);
+            Assert.False(regions[0].IncludeIsVirtual);
+            Assert.Equal(AspRegionType.Html, regions[1].Type);
+        }
+
+        [Fact]
+        public void AspParser_NestsHtmlInsideIfElseBlocksInsteadOfFlatteningAfterThem()
+        {
+            var page = new AspParser().Parse("<% If x = 1 Then %>A<% Else %>B<% End If %>");
+
+            var ifStmt = Assert.IsType<IfStatementNode>(Assert.Single(page.Statements));
+            var trueHtml = Assert.IsType<HtmlOutputStatementNode>(Assert.Single(ifStmt.TrueBlock.Statements));
+            Assert.Equal("A", trueHtml.Html);
+            var elseHtml = Assert.IsType<HtmlOutputStatementNode>(Assert.Single(ifStmt.ElseBlock!.Statements));
+            Assert.Equal("B", elseHtml.Html);
+        }
+
+        [Fact]
+        public void AspParser_ParsesSingleLineIfWithNoEndIf()
+        {
+            var page = new AspParser().Parse("<% If loggedIn Then Response.Write \"hi\" %>");
+
+            var single = Assert.IsType<SingleLineIfStatementNode>(Assert.Single(page.Statements));
+            var call = Assert.IsType<CallStatementNode>(single.ThenStatement);
+            var invocation = Assert.IsType<InvocationExpressionNode>(call.Invocation);
+            Assert.Single(invocation.Arguments);
+        }
+
+        [Fact]
+        public void AspParser_ParsesClassicRecordsetLoopWithHtmlNestedInWhileBody()
+        {
+            // The exact pattern documented in ProjectPlan.md's "Data Binding Patterns" section.
+            var asp = "<% While Not rs.EOF %><tr><td><%=rs(\"Name\")%></td></tr><% rs.MoveNext %><% Wend %>";
+            var page = new AspParser().Parse(asp);
+
+            var whileStmt = Assert.IsType<WhileStatementNode>(Assert.Single(page.Statements));
+            Assert.Contains(whileStmt.Body.Statements, s => s is HtmlOutputStatementNode html && html.Html.Contains("<tr>"));
+            Assert.Contains(whileStmt.Body.Statements, s => s is AspOutputExpressionStatementNode);
+            Assert.Contains(whileStmt.Body.Statements, s => s is CallStatementNode);
+        }
+
+        [Fact]
+        public void AspParser_ParsesParenlessStatementCallWithMultipleArguments()
+        {
+            var page = new AspParser().Parse("<% Response.Write \"hello\", \"world\" %>");
+
+            var call = Assert.IsType<CallStatementNode>(Assert.Single(page.Statements));
+            var invocation = Assert.IsType<InvocationExpressionNode>(call.Invocation);
+            Assert.Equal(2, invocation.Arguments.Count);
+        }
+
+        [Fact]
+        public void AspParser_ParsesForEachOverServerVariablesStyleCollection()
+        {
+            var page = new AspParser().Parse("<% For Each item In items %><%=item%><% Next %>");
+
+            var forEach = Assert.IsType<ForEachStatementNode>(Assert.Single(page.Statements));
+            Assert.Equal("item", forEach.LoopVariable);
+            Assert.Single(forEach.Body.Statements);
+        }
+
+        [Fact]
+        public void AspParser_DoesNotRunTogetherStatementsFromSeparateCodeBlocks()
+        {
+            // Without a synthetic break between adjacent <% %> tags, this would misparse
+            // as a parenless call `rs.MoveNext(x)` followed by a stray `= 1`.
+            var page = new AspParser().Parse("<% rs.MoveNext %><% x = 1 %>");
+
+            Assert.Equal(2, page.Statements.Count);
+            Assert.IsType<CallStatementNode>(page.Statements[0]);
+            Assert.IsType<AssignmentNode>(page.Statements[1]);
+        }
+
+        [Fact]
+        public void AspParser_ParsesDimWithMultipleNames()
+        {
+            var page = new AspParser().Parse("<% Dim a, b, c %>");
+
+            var group = Assert.IsType<VariableDeclarationGroupNode>(Assert.Single(page.Statements));
+            Assert.Equal(new[] { "a", "b", "c" }, group.Declarations.Select(d => d.Name));
+        }
+
+        [Fact]
+        public void AspParser_ExtractsDirectiveAttributes()
+        {
+            var page = new AspParser().Parse("<%@ Language=\"VBScript\" CodePage=\"65001\" %>");
+
+            var directive = Assert.Single(page.Directives);
+            Assert.Equal("VBScript", directive.Attributes["Language"]);
+            Assert.Equal("65001", directive.Attributes["CodePage"]);
+        }
+
+        [Fact]
+        public void IncludeFileResolver_SplicesFileRelativeInclude()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "BLML.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            try
+            {
+                var headerPath = Path.Combine(root, "header.asp");
+                File.WriteAllText(headerPath, "<b>Header</b>");
+                var mainPath = Path.Combine(root, "main.asp");
+                File.WriteAllText(mainPath, "<!--#include file=\"header.asp\"-->Body");
+
+                var page = new AspParser().Parse(File.ReadAllText(mainPath), mainPath, root);
+
+                var html = Assert.IsType<HtmlOutputStatementNode>(Assert.Single(page.Statements));
+                Assert.Equal("<b>Header</b>Body", html.Html);
+                Assert.Single(page.ResolvedIncludePaths);
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        [Fact]
+        public void IncludeFileResolver_DetectsCircularIncludes()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "BLML.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            try
+            {
+                var aPath = Path.Combine(root, "a.asp");
+                var bPath = Path.Combine(root, "b.asp");
+                File.WriteAllText(aPath, "<!--#include file=\"b.asp\"-->");
+                File.WriteAllText(bPath, "<!--#include file=\"a.asp\"-->");
+
+                var resolver = new IncludeFileResolver(root);
+                var result = resolver.ResolveIncludes(File.ReadAllText(aPath), aPath);
+
+                Assert.Contains(result.Warnings, w => w.Contains("Circular include"));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/BLML.Tests/Phase5AspToAngularTests.cs
+++ b/tests/BLML.Tests/Phase5AspToAngularTests.cs
@@ -6,11 +6,67 @@ using BLML.Phase5ASPtoAngular.Backend.ApiGenerator;
 using BLML.Phase5ASPtoAngular.Backend.Infrastructure;
 using BLML.Phase5ASPtoAngular.Frontend;
 using BLML.Phase5ASPtoAngular.Database;
+using BLML.Phase5ASPtoAngular;
 
 namespace BLML.Tests
 {
     public class Phase5AspToAngularTests
     {
+        [Fact]
+        public void AspProjectConverter_ConvertsAMiniAspAppIntoApiClientAppAndDatabaseArtifacts()
+        {
+            var root = Path.Combine(Path.GetTempPath(), "BLML.Tests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(root);
+            try
+            {
+                File.WriteAllText(Path.Combine(root, "index.asp"),
+                    "<html><body><a href=\"products.asp\">Products</a></body></html>");
+
+                File.WriteAllText(Path.Combine(root, "products.asp"), string.Join("\n",
+                    "<%",
+                    "Set rs = Server.CreateObject(\"ADODB.Recordset\")",
+                    "rs.Open \"SELECT * FROM Products\", conn",
+                    "%>",
+                    "<html><body><ul>",
+                    "<% While Not rs.EOF %>",
+                    "<li><%=rs(\"Name\")%></li>",
+                    "<% rs.MoveNext %>",
+                    "<% Wend %>",
+                    "</ul></body></html>"));
+
+                var converter = new AspProjectConverter();
+                var outputDir = Path.Combine(root, "out");
+
+                var result = converter.ConvertDirectory(root, outputDir);
+
+                Assert.True(File.Exists(Path.Combine(outputDir, "Api", "Dtos", "ProductsDto.cs")));
+                Assert.True(File.Exists(Path.Combine(outputDir, "Api", "Services", "ProductsService.cs")));
+                Assert.True(File.Exists(Path.Combine(outputDir, "Api", "Controllers", "ProductsController.cs")));
+                Assert.True(File.Exists(Path.Combine(outputDir, "Api", "Program.cs")));
+                Assert.True(File.Exists(Path.Combine(outputDir, "Database", "schema.sql")));
+                Assert.True(File.Exists(Path.Combine(outputDir, "ClientApp", "src", "app", "products", "products.component.ts")));
+                Assert.True(File.Exists(Path.Combine(outputDir, "ClientApp", "src", "app", "products", "products.component.html")));
+                Assert.True(File.Exists(Path.Combine(outputDir, "ClientApp", "src", "app", "app.routes.ts")));
+
+                var serviceCode = File.ReadAllText(Path.Combine(outputDir, "Api", "Services", "ProductsService.cs"));
+                Assert.Contains("SqlCommand", serviceCode);
+
+                var templateHtml = File.ReadAllText(Path.Combine(outputDir, "ClientApp", "src", "app", "products", "products.component.html"));
+                Assert.Contains("@for (item of rsItems(); track item.id)", templateHtml);
+
+                var routes = File.ReadAllText(Path.Combine(outputDir, "ClientApp", "src", "app", "app.routes.ts"));
+                Assert.Contains("path: ''", routes); // index.asp is the home page
+                Assert.Contains("products", routes);
+
+                // No anti-pattern findings should have leaked through as warnings for this simple page.
+                Assert.DoesNotContain(result.Warnings, w => w.Contains("no-legacy-structural-directives") || w.Contains("component-must-be-standalone"));
+            }
+            finally
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
         [Fact]
         public void EFCoreGenerator_BuildsTableMetadataFromAspFieldUsageAndDelegatesToPhase4()
         {

--- a/tests/BLML.Tests/Phase5AspToAngularTests.cs
+++ b/tests/BLML.Tests/Phase5AspToAngularTests.cs
@@ -8,6 +8,70 @@ namespace BLML.Tests
     public class Phase5AspToAngularTests
     {
         [Fact]
+        public void SessionVariableTracker_CatalogsReadsWritesAndAllThreeNullCheckIdioms()
+        {
+            var asp = "<% Session(\"UserId\") = 42 %>"
+                     + "<% If Session(\"UserId\") = \"\" Then %>A<% End If %>"
+                     + "<% If IsEmpty(Session(\"UserId\")) Then %>B<% End If %>"
+                     + "<% If Session(\"UserId\") Is Nothing Then %>C<% End If %>";
+            var page = new AspParser().Parse(asp);
+
+            var catalog = new SessionVariableTracker().Catalog(page.Statements);
+
+            var info = catalog["UserId"];
+            Assert.Single(info.WriteSites);
+            Assert.Equal(3, info.ReadSites.Count);
+            Assert.Contains(SessionNullCheckIdiom.EqualsEmptyString, info.NullCheckIdiomsObserved);
+            Assert.Contains(SessionNullCheckIdiom.IsEmptyCall, info.NullCheckIdiomsObserved);
+            Assert.Contains(SessionNullCheckIdiom.IsNothingComparison, info.NullCheckIdiomsObserved);
+        }
+
+        [Fact]
+        public void DatabaseCallAnalyzer_FlagsSqlBuiltByUnsafeConcatenationAndExtractsTableName()
+        {
+            var asp = "<% Set rs = Server.CreateObject(\"ADODB.Recordset\") %>"
+                     + "<% rs.Open \"SELECT * FROM Users WHERE Id=\" & userId, conn %>";
+            var page = new AspParser().Parse(asp);
+
+            var results = new DatabaseCallAnalyzer().Analyze(page.Statements);
+
+            var rsInfo = Assert.Single(results);
+            Assert.Equal(AdoObjectKind.Recordset, rsInfo.Kind);
+            var callSite = Assert.Single(rsInfo.CallSites);
+            Assert.True(callSite.BuiltByUnsafeConcatenation);
+            Assert.Contains("Users", callSite.TablesReferenced);
+        }
+
+        [Fact]
+        public void DatabaseCallAnalyzer_DoesNotFlagPureLiteralSqlAsUnsafe()
+        {
+            var asp = "<% Set rs = Server.CreateObject(\"ADODB.Recordset\") %>"
+                     + "<% rs.Open \"SELECT * FROM Products\", conn %>";
+            var page = new AspParser().Parse(asp);
+
+            var results = new DatabaseCallAnalyzer().Analyze(page.Statements);
+
+            var callSite = Assert.Single(Assert.Single(results).CallSites);
+            Assert.False(callSite.BuiltByUnsafeConcatenation);
+            Assert.Contains("Products", callSite.TablesReferenced);
+        }
+
+        [Fact]
+        public void PageFlowAnalyzer_FindsServerRedirectFormAndLinkTargets()
+        {
+            var asp = "<% If Not loggedIn Then Response.Redirect \"login.asp\" %>"
+                     + "<form action=\"save.asp\" method=\"post\"></form>"
+                     + "<a href=\"details.asp?id=1\">details</a>";
+            var page = new AspParser().Parse(asp);
+
+            var edges = new PageFlowAnalyzer().Analyze(page.Statements, "index.asp");
+
+            Assert.Contains(edges, e => e.ToPage == "login.asp" && e.Trigger == PageFlowTrigger.Redirect);
+            Assert.Contains(edges, e => e.ToPage == "save.asp" && e.Trigger == PageFlowTrigger.FormSubmit && e.HttpMethod == "POST");
+            Assert.Contains(edges, e => e.ToPage == "details.asp" && e.Trigger == PageFlowTrigger.Link);
+        }
+
+        [Fact]
         public void GlobalAsaParser_ExtractsLifecycleEventsAndObjectDeclarations()
         {
             var content = @"

--- a/tests/BLML.Tests/Phase8CliTests.cs
+++ b/tests/BLML.Tests/Phase8CliTests.cs
@@ -189,6 +189,44 @@ public class Phase8CliTests
         }
     }
 
+    [Fact]
+    public async Task CommandLineInterface_ShouldConvertAspProject()
+    {
+        var cli = new CommandLineInterface();
+        var root = CreateTempFolder();
+
+        try
+        {
+            await File.WriteAllTextAsync(Path.Combine(root, "index.asp"), "<html><body>Home</body></html>");
+            var outputPath = Path.Combine(root, "out");
+
+            using var output = new StringWriter();
+            using var error = new StringWriter();
+            var exitCode = await cli.RunAsync(["convert-asp-project", "--input", root, "--output", outputPath], output, error);
+
+            Assert.Equal((int)CliExitCode.Success, exitCode);
+            Assert.True(File.Exists(Path.Combine(outputPath, "ClientApp", "src", "app", "index", "index.component.ts")));
+            Assert.Contains("[progress]", output.ToString());
+        }
+        finally
+        {
+            Directory.Delete(root, true);
+        }
+    }
+
+    [Fact]
+    public async Task CommandLineInterface_ShouldReturnInputNotFoundForMissingAspDirectory()
+    {
+        var cli = new CommandLineInterface();
+        using var output = new StringWriter();
+        using var error = new StringWriter();
+
+        var exitCode = await cli.RunAsync(["convert-asp-project", "--input", "missing-dir"], output, error);
+
+        Assert.Equal((int)CliExitCode.InputNotFound, exitCode);
+        Assert.Contains("input directory", error.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
     private static string CreateTempFolder()
     {
         var path = Path.Combine(Path.GetTempPath(), "BLML.Tests", Guid.NewGuid().ToString("N"));


### PR DESCRIPTION
## Summary

Implements Phase 5 (ASP → Angular + .NET Core + SQL Server), closing #10, #11, #12, #13, and #14. Every piece under `src/Phase5-ASPtoAngular/` was previously an empty stub with a one-line comment; this replaces all of them with real, tested implementations and wires them into one end-to-end pipeline.

- **Parser** (`AspParser/`) - classic ASP/VBScript lexer + recursive-descent parser. Specifically handles classic-ASP ambiguities: HTML written inside `<% If %>...<% End If %>` nests correctly in the AST instead of flattening after the block; single-line vs. block `If` (needed a dedicated line-aware tokenizer, since the shared `VB6Lexer` other phases depend on discards newlines); `%>` inside string literals; `#include file/virtual="..."` resolution with circular-include detection; the VB-family parenless statement-call ambiguity.
- **Analysis** (`Analysis/`) - `SessionVariableTracker` (normalizes 3 different "is this session value unset" idioms into one check), `DatabaseCallAnalyzer` (flags SQL built by unsafe string concatenation), `PageFlowAnalyzer`, `BusinessLogicExtractor`.
- **Backend** (`Backend/`) - .NET 8 Web API generation. `ServiceGenerator` *always* emits parameterized SQL regardless of whether the source page concatenated safely; `ControllerGenerator` derives the REST verb from the SQL statement; JWT auth via `AuthConverter`; full `Program.cs` via `MiddlewareGenerator`.
- **Frontend** (`Frontend/`) - standalone Angular 17+ generation (`@if`/`@for`, `inject()`, signals, typed Reactive Forms - the modern Angular baseline most current tooling and AI assistants target) plus a real `AngularAntiPatternChecker` that every generated component is run back through before being returned - a build-time gate, not just documented intent, covered by a test that fails if the generator ever regresses into a legacy pattern.
- **Database** (`Database/`) - delegates to Phase 4's already-implemented EF Core/schema generators rather than duplicating them.
- **`AspProjectConverter`** ties everything into one pipeline, exposed via a new CLI command: `convert-asp-project --input <folder> --output <folder>`.

Also resolves an open question left by an earlier, abandoned Blazor/Razor prototype under `src/Phase5-ASPtoAngular/RazorPages/`, whose own docs explicitly asked "decide whether Phase5 should stay Blazor/Razor-based, or align with Angular." That's now answered (Angular) and recorded in both `README.md` and `docs/Phase5-ASPtoAngular-TODO.md` - the prototype and its file-inventory tests are untouched.

## Test plan

- [x] `dotnet build` succeeds
- [x] `dotnet test` - 103 passed, 1 pre-existing skip, 0 failed (up from 63/64 on `main`)
- [x] New `Phase5AspToAngularTests.cs` covers each component individually, including an end-to-end test that runs a small multi-page ASP app through the full pipeline and asserts on generated file content
- [x] New CLI tests in `Phase8CliTests.cs` for `convert-asp-project`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>